### PR TITLE
Add configurable transport support for MCP server (stdio/SSE)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,17 +17,16 @@ CLOCKODO_EXTERNAL_APP_CONTACT=your@email.com
 # This .env file is for local development/testing only.
 # ============================================
 
-# Quick Presets (choose one):
-# CLOCKODO_MCP_PRESET=readonly  # HR analytics only (default)
-# CLOCKODO_MCP_PRESET=user      # HR + your own time entries
-# CLOCKODO_MCP_PRESET=admin     # All features
+# Role-based configuration (recommended):
+# CLOCKODO_MCP_ROLE=employee       # Track your own time (default)
+# CLOCKODO_MCP_ROLE=team_leader    # Employee + approve vacations & edit team entries
+# CLOCKODO_MCP_ROLE=hr_analytics   # View HR compliance reports only
+# CLOCKODO_MCP_ROLE=admin          # Full access to everything
 
-# Or use granular flags:
-# CLOCKODO_MCP_ENABLE_HR_READONLY=true      # HR compliance analytics
-# CLOCKODO_MCP_ENABLE_USER_READ=true        # Read your time entries
-# CLOCKODO_MCP_ENABLE_USER_EDIT=true        # Edit your time entries
-# CLOCKODO_MCP_ENABLE_ADMIN_READ=true       # Read all users' data
-# CLOCKODO_MCP_ENABLE_ADMIN_EDIT=true       # Edit all users' data
+# Transport configuration:
+# CLOCKODO_MCP_TRANSPORT=stdio     # stdin/stdout for local processes (default)
+# CLOCKODO_MCP_TRANSPORT=sse       # HTTP/SSE for remote access
+# CLOCKODO_MCP_PORT=8000           # Port for SSE transport (default: 8000)
 
 # ============================================
 # Manual Testing Configuration

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ if config.is_enabled(FeatureGroup.ADMIN_EDIT):
 
 ### Option 1: Using Pre-built Docker Image from GitHub Container Registry
 
+#### For Local MCP Clients (Claude Desktop, IDEs) - stdio transport
+
 Add configuration to your IDE's MCP settings (e.g., Claude Desktop):
 
 ```json
@@ -265,6 +267,19 @@ Add configuration to your IDE's MCP settings (e.g., Claude Desktop):
 }
 ```
 
+#### For Remote Access (Web Apps) - HTTP/SSE transport
+
+```bash
+docker run -d \
+  -p 8000:8000 \
+  -e CLOCKODO_API_USER=your@email.com \
+  -e CLOCKODO_API_KEY=your_api_key \
+  -e CLOCKODO_MCP_ROLE=employee \
+  -e CLOCKODO_MCP_TRANSPORT=sse \
+  -e CLOCKODO_MCP_PORT=8000 \
+  ghcr.io/pfaeffli/clockodo-mcp-server:latest
+```
+
 **Available image tags:**
 - `latest` - Latest stable release
 - `v1.0.0`, `v1.0`, `v1` - Semantic version tags
@@ -289,6 +304,12 @@ Add configuration to your IDE's MCP settings (e.g., Claude Desktop):
 - `CLOCKODO_USER_AGENT` - Custom user agent string (default: "clockodo-mcp/unknown")
 - `CLOCKODO_BASE_URL` - API base URL (default: "https://my.clockodo.com/api/v2/")
 - `CLOCKODO_EXTERNAL_APP_CONTACT` - Contact info for external app header (default: API user email)
+
+### Transport Configuration (Optional)
+- `CLOCKODO_MCP_TRANSPORT` - Transport protocol (default: "stdio")
+  - `stdio` - Standard input/output for local processes (Claude Desktop, IDEs)
+  - `sse` - HTTP/SSE for remote access and web applications
+- `CLOCKODO_MCP_PORT` - Port for SSE transport (default: 8000)
 
 ### Role Configuration (Recommended)
 

--- a/src/clockodo_mcp/server.py
+++ b/src/clockodo_mcp/server.py
@@ -29,8 +29,8 @@ from . import resources as resource_handlers
 # Load configuration from environment variables with safe defaults
 config = ServerConfig.from_env()
 
-# Create MCP server instance
-mcp = FastMCP("clockodo")
+# Create MCP server instance with configured port
+mcp = FastMCP("clockodo", port=config.port)
 
 
 @mcp.tool()
@@ -447,5 +447,8 @@ register_tools()
 
 
 def main() -> None:
-    """Run the MCP server using stdio transport."""
-    mcp.run(transport="stdio")
+    """Run the MCP server using configured transport."""
+    if config.transport == "sse":
+        mcp.run(transport="sse")
+    else:
+        mcp.run(transport="stdio")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,3 +90,35 @@ def test_config_env_boolean_parsing(monkeypatch):
     assert config.user_read is True
     assert config.user_edit is True
     assert config.admin_read is True
+
+
+def test_config_default_transport():
+    config = ServerConfig()
+    assert config.transport == "stdio"
+    assert config.port == 8000
+
+
+def test_config_transport_from_env_stdio(monkeypatch):
+    monkeypatch.setenv("CLOCKODO_MCP_TRANSPORT", "stdio")
+    config = ServerConfig.from_env()
+    assert config.transport == "stdio"
+
+
+def test_config_transport_from_env_sse(monkeypatch):
+    monkeypatch.setenv("CLOCKODO_MCP_TRANSPORT", "sse")
+    monkeypatch.setenv("CLOCKODO_MCP_PORT", "9000")
+    config = ServerConfig.from_env()
+    assert config.transport == "sse"
+    assert config.port == 9000
+
+
+def test_config_transport_invalid_defaults_to_stdio(monkeypatch):
+    monkeypatch.setenv("CLOCKODO_MCP_TRANSPORT", "invalid")
+    config = ServerConfig.from_env()
+    assert config.transport == "stdio"
+
+
+def test_config_transport_case_insensitive(monkeypatch):
+    monkeypatch.setenv("CLOCKODO_MCP_TRANSPORT", "SSE")
+    config = ServerConfig.from_env()
+    assert config.transport == "sse"


### PR DESCRIPTION
Adds environment-based transport configuration to support both local (stdio) and remote (HTTP/SSE) deployments. 

The server now accepts CLOCKODO_MCP_TRANSPORT to select between stdio (default, for Claude Desktop/IDEs) and sse (for web applications), with CLOCKODO_MCP_PORT to configure the SSE port (default: 8000).

Changes:
- Add transport and port configuration to ServerConfig
- Configure FastMCP instance with port from environment
- Update main() to conditionally use stdio or SSE transport
- Update documentation (.env.example, README.md) with transport options