### PR TITLE
Fix date format handling to prevent 400 errors

### DIFF
--- a/src/clockodo_mcp/date_utils.py
+++ b/src/clockodo_mcp/date_utils.py
@@ -1,0 +1,52 @@
+"""Datetime normalization utilities for Clockodo API compatibility."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import overload
+
+
+@overload
+def normalize_datetime(value: str) -> str: ...
+
+
+@overload
+def normalize_datetime(value: None) -> None: ...
+
+
+def normalize_datetime(value: str | None) -> str | None:
+    """
+    Normalize a datetime string to ISO 8601 format for the Clockodo API.
+
+    Handles common LLM-generated formats:
+    - "2025-01-01 09:00:00" → "2025-01-01T09:00:00Z"
+    - "2025-01-01T09:00:00" → "2025-01-01T09:00:00Z"
+    - "2025-01-01T09:00:00Z" → "2025-01-01T09:00:00Z" (passthrough)
+    - "2025-01-01T09:00:00+01:00" → "2025-01-01T09:00:00+01:00" (passthrough)
+
+    Args:
+        value: Datetime string or None.
+
+    Returns:
+        Normalized ISO 8601 string, or None if input is None.
+
+    Raises:
+        ValueError: If the string cannot be parsed as a valid datetime.
+    """
+    if value is None:
+        return None
+
+    # Replace space separator with T
+    normalized = value.replace(" ", "T", 1)
+
+    # Validate by parsing
+    try:
+        datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Invalid datetime format: {value!r}") from exc
+
+    # Append Z if no timezone info present
+    if "+" not in normalized and not normalized.endswith("Z"):
+        normalized += "Z"
+
+    return normalized

--- a/src/clockodo_mcp/server.py
+++ b/src/clockodo_mcp/server.py
@@ -243,8 +243,8 @@ def _register_user_read_tools():
         Get time entries for the authenticated user in a given time range.
 
         Args:
-            time_since: Start time (e.g., 2025-01-01 00:00:00)
-            time_until: End time (e.g., 2025-01-01 23:59:59)
+            time_since: Start time (e.g., 2025-01-01T00:00:00Z)
+            time_until: End time (e.g., 2025-01-01T23:59:59Z)
         """
         return user_tools.get_my_entries(time_since, time_until)
 
@@ -310,8 +310,8 @@ def _register_user_edit_tools():
         Args:
             customers_id: ID of the customer
             services_id: ID of the service
-            time_since: Start time (e.g., 2025-01-01 09:00:00)
-            time_until: End time (e.g., 2025-01-01 10:00:00)
+            time_since: Start time (e.g., 2025-01-01T09:00:00Z)
+            time_until: End time (e.g., 2025-01-01T10:00:00Z)
             billable: Whether the entry is billable (1) or not (0)
             projects_id: Optional project ID
             text: Optional description

--- a/src/clockodo_mcp/services/user_service.py
+++ b/src/clockodo_mcp/services/user_service.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 
 import httpx
 
+from ..date_utils import normalize_datetime
+
 if TYPE_CHECKING:
     from ..client import ClockodoClient
 
@@ -95,8 +97,8 @@ class UserService:
         """Get time entries for the current user."""
         user_id = self.get_current_user_id()
         return self.client.list_entries(
-            time_since=time_since,
-            time_until=time_until,
+            time_since=normalize_datetime(time_since),
+            time_until=normalize_datetime(time_until),
             user_id=user_id,
         )
 
@@ -116,8 +118,8 @@ class UserService:
             customers_id=customers_id,
             services_id=services_id,
             billable=billable,
-            time_since=time_since,
-            time_until=time_until,
+            time_since=normalize_datetime(time_since),
+            time_until=normalize_datetime(time_until),
             projects_id=projects_id,
             text=text,
             user_id=user_id,

--- a/src/clockodo_mcp/tools/user_tools.py
+++ b/src/clockodo_mcp/tools/user_tools.py
@@ -66,8 +66,8 @@ def get_my_entries(time_since: str, time_until: str) -> dict:
     Get time entries for the authenticated user in a given time range.
 
     Args:
-        time_since: Start time (e.g., 2025-01-01 00:00:00)
-        time_until: End time (e.g., 2025-01-01 23:59:59)
+        time_since: Start time (e.g., 2025-01-01T00:00:00Z)
+        time_until: End time (e.g., 2025-01-01T23:59:59Z)
     """
     client = ClockodoClient.from_env()
     service = UserService(client)
@@ -89,8 +89,8 @@ def add_my_entry(
     Args:
         customers_id: ID of the customer
         services_id: ID of the service
-        time_since: Start time (e.g., 2025-01-01 09:00:00)
-        time_until: End time (e.g., 2025-01-01 10:00:00)
+        time_since: Start time (e.g., 2025-01-01T09:00:00Z)
+        time_until: End time (e.g., 2025-01-01T10:00:00Z)
         billable: Whether the entry is billable (1) or not (0)
         projects_id: Optional project ID
         text: Optional description

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,43 @@
+import pytest
+
+from clockodo_mcp.date_utils import normalize_datetime
+
+
+def test_iso8601_passthrough():
+    """Already correct ISO 8601 format should pass through unchanged."""
+    assert normalize_datetime("2025-01-01T09:00:00Z") == "2025-01-01T09:00:00Z"
+
+
+def test_space_separated_converted_to_iso():
+    """Space-separated datetime should be converted to ISO 8601."""
+    assert normalize_datetime("2025-01-01 09:00:00") == "2025-01-01T09:00:00Z"
+
+
+def test_missing_z_appended():
+    """ISO 8601 without Z should get Z appended."""
+    assert normalize_datetime("2025-01-01T09:00:00") == "2025-01-01T09:00:00Z"
+
+
+def test_with_timezone_offset_passthrough():
+    """Datetime with timezone offset should pass through without adding Z."""
+    assert (
+        normalize_datetime("2025-01-01T09:00:00+01:00") == "2025-01-01T09:00:00+01:00"
+    )
+
+
+def test_none_returns_none():
+    """None input should return None."""
+    assert normalize_datetime(None) is None
+
+
+def test_invalid_datetime_raises():
+    """Invalid datetime string should raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid datetime format"):
+        normalize_datetime("not-a-date")
+
+
+def test_space_separated_with_timezone_offset():
+    """Space-separated with timezone offset should convert space to T only."""
+    assert (
+        normalize_datetime("2025-01-01 09:00:00+01:00") == "2025-01-01T09:00:00+01:00"
+    )

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -219,6 +219,57 @@ def test_add_my_entry():
     assert result["entry"]["id"] == 3001
 
 
+def test_get_my_entries_normalizes_dates():
+    """Service layer should normalize space-separated dates to ISO 8601."""
+    client = MagicMock()
+    client.api_user = "alice@example.com"
+    client.list_users.return_value = {
+        "users": [{"id": 42, "email": "alice@example.com"}]
+    }
+    client.list_entries.return_value = {"entries": []}
+
+    service = UserService(client)
+    service.get_my_entries(
+        time_since="2025-01-01 00:00:00", time_until="2025-01-01 23:59:59"
+    )
+
+    client.list_entries.assert_called_once_with(
+        time_since="2025-01-01T00:00:00Z",
+        time_until="2025-01-01T23:59:59Z",
+        user_id=42,
+    )
+
+
+def test_add_my_entry_normalizes_dates():
+    """Service layer should normalize space-separated dates to ISO 8601."""
+    client = MagicMock()
+    client.api_user = "alice@example.com"
+    client.list_users.return_value = {
+        "users": [{"id": 42, "email": "alice@example.com"}]
+    }
+    client.create_entry.return_value = {"entry": {"id": 3001}}
+
+    service = UserService(client)
+    service.add_my_entry(
+        customers_id=123,
+        services_id=456,
+        billable=1,
+        time_since="2025-01-01 09:00:00",
+        time_until="2025-01-01 10:00:00",
+    )
+
+    client.create_entry.assert_called_once_with(
+        customers_id=123,
+        services_id=456,
+        billable=1,
+        time_since="2025-01-01T09:00:00Z",
+        time_until="2025-01-01T10:00:00Z",
+        projects_id=None,
+        text=None,
+        user_id=42,
+    )
+
+
 def test_edit_my_entry():
     """Test editing an entry."""
     client = MagicMock()


### PR DESCRIPTION
## Problem

The `add_my_time_entry` and `get_my_time_entries` tools return **400 Bad Request** because their docstrings show space-separated date examples (`2025-01-01 09:00:00`), which LLMs follow when calling the tools. The Clockodo API requires ISO 8601 format (`2025-01-01T09:00:00Z`).

## Solution

**Two-layer fix** — correct the docstrings *and* add defensive normalization so the API calls succeed even if an LLM still sends the wrong format:

1. **`normalize_datetime()` utility** (`date_utils.py`): Converts common datetime variants to ISO 8601 — replaces space with `T`, appends `Z` when no timezone is present, validates with `datetime.fromisoformat()`. Uses `@overload` for type-safe `str → str` / `None → None` signatures.

2. **Service-layer normalization** (`user_service.py`): `get_my_entries()` and `add_my_entry()` now call `normalize_datetime()` on `time_since`/`time_until` before passing them to the client.

3. **Docstring fix** (`server.py`, `user_tools.py`): Updated all date examples from `2025-01-01 09:00:00` to `2025-01-01T09:00:00Z`.

Fixes #9

## Test plan

- [x] 7 unit tests for `normalize_datetime()` — ISO passthrough, space-separated conversion, missing Z, timezone offsets, `None`, invalid input
- [x] 2 service-layer tests verifying dates are normalized before client calls
- [x] All 184 tests pass
- [x] pylint 10.00/10, mypy 0 errors, black clean