### PR TITLE
Add test coverage for text parameter in time entries (#12)

### DIFF
--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -267,6 +267,40 @@ def test_add_my_entry_tool(mock_client_class):
 
 
 @patch("clockodo_mcp.tools.user_tools.ClockodoClient")
+def test_add_my_entry_tool_with_text(mock_client_class):
+    mock_client = Mock()
+    mock_client_class.from_env.return_value = mock_client
+    mock_client.api_user = "me@example.com"
+    mock_client.list_users.return_value = {
+        "users": [{"id": 42, "email": "me@example.com"}]
+    }
+    mock_client.create_entry.return_value = {
+        "entry": {"id": 301, "text": "Test description", "texts_id": 999}
+    }
+
+    result = add_my_entry(
+        customers_id=123,
+        services_id=456,
+        time_since="2025-01-01T09:00:00Z",
+        time_until="2025-01-01T10:00:00Z",
+        billable=0,
+        text="Test description",
+    )
+
+    mock_client.create_entry.assert_called_once_with(
+        customers_id=123,
+        services_id=456,
+        billable=0,
+        time_since="2025-01-01T09:00:00Z",
+        time_until="2025-01-01T10:00:00Z",
+        projects_id=None,
+        text="Test description",
+        user_id=42,
+    )
+    assert result["entry"]["id"] == 301
+
+
+@patch("clockodo_mcp.tools.user_tools.ClockodoClient")
 def test_edit_my_entry_tool(mock_client_class):
     mock_client = Mock()
     mock_client_class.from_env.return_value = mock_client

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -270,6 +270,40 @@ def test_add_my_entry_normalizes_dates():
     )
 
 
+def test_add_my_entry_with_text():
+    """Test that text parameter is passed through to the client."""
+    client = MagicMock()
+    client.api_user = "alice@example.com"
+    client.list_users.return_value = {
+        "users": [{"id": 42, "email": "alice@example.com"}]
+    }
+    client.create_entry.return_value = {
+        "entry": {"id": 3001, "text": "Work description", "texts_id": 555}
+    }
+
+    service = UserService(client)
+    result = service.add_my_entry(
+        customers_id=123,
+        services_id=456,
+        billable=0,
+        time_since="2025-01-01T09:00:00Z",
+        time_until="2025-01-01T10:00:00Z",
+        text="Work description",
+    )
+
+    client.create_entry.assert_called_once_with(
+        customers_id=123,
+        services_id=456,
+        billable=0,
+        time_since="2025-01-01T09:00:00Z",
+        time_until="2025-01-01T10:00:00Z",
+        projects_id=None,
+        text="Work description",
+        user_id=42,
+    )
+    assert result["entry"]["text"] == "Work description"
+
+
 def test_edit_my_entry():
     """Test editing an entry."""
     client = MagicMock()


### PR DESCRIPTION
## Summary
- Adds tests verifying the `text` parameter correctly flows through all layers (tool → service → client → HTTP request body) when creating time entries
- Investigation of issue #12 confirms the code is correct at every layer - `text` is properly included in the JSON request body sent to the Clockodo API
- The root cause appears to be on the Clockodo API side (API accepts the field but doesn't persist it)

## Investigation Details
- MCP tool schema correctly includes `text` as an optional string parameter
- Tool layer (`user_tools.py`) passes `text` to service layer
- Service layer (`user_service.py`) passes `text` to client layer  
- Client layer (`client.py`) includes `text` in the HTTP POST body
- HTTP request is sent as `application/json` with `text` in the body
- All 186 tests pass

## Test plan
- [x] New tests verify text flows from tool → service → client
- [x] Existing test `test_create_entry_with_all_optional_params` verifies HTTP request body
- [x] All 186 tests pass

Closes #12