### PR TITLE
chore: refresh OpenAPI spec to 2026-05-06; drop /v2/ from default base URL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+specification/openapi.yaml linguist-generated=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /app
 COPY --from=builder /install /usr/local
 
 # Default env vars for Clockodo (override at runtime)
-ENV CLOCKODO_BASE_URL="https://my.clockodo.com/api/v2/"
+ENV CLOCKODO_BASE_URL="https://my.clockodo.com/api/"
 
 USER appuser
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Add configuration to your IDE's MCP settings (e.g., Claude Desktop):
         "-e",
         "CLOCKODO_USER_AGENT=my-company/1.0",
         "-e",
-        "CLOCKODO_BASE_URL=https://my.clockodo.com/api/v2/",
+        "CLOCKODO_BASE_URL=https://my.clockodo.com/api/",
         "-e",
         "CLOCKODO_EXTERNAL_APP_CONTACT=dev@company.com",
         "-e",
@@ -315,7 +315,7 @@ docker run -d \
 
 ### API Configuration (Optional)
 - `CLOCKODO_USER_AGENT` - Custom user agent string (default: "clockodo-mcp/unknown")
-- `CLOCKODO_BASE_URL` - API base URL (default: "https://my.clockodo.com/api/v2/")
+- `CLOCKODO_BASE_URL` - API base URL (default: "https://my.clockodo.com/api/")
 - `CLOCKODO_EXTERNAL_APP_CONTACT` - Contact info for external app header (default: API user email)
 
 ### Transport Configuration (Optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       CLOCKODO_API_USER: ${CLOCKODO_API_USER}
       CLOCKODO_API_KEY: ${CLOCKODO_API_KEY}
       CLOCKODO_USER_AGENT: ${CLOCKODO_USER_AGENT-clockodo-mcp/0.1.0}
-      CLOCKODO_BASE_URL: ${CLOCKODO_BASE_URL-https://my.clockodo.com/api/v2/}
+      CLOCKODO_BASE_URL: ${CLOCKODO_BASE_URL-https://my.clockodo.com/api/}
     # Example of how an MCP stdio server might be used by a host tool via stdin/stdout.
     # Here we just run the entrypoint which prints a health check for now.
     command: ["clockodo-mcp"]

--- a/specification/README.md
+++ b/specification/README.md
@@ -1,0 +1,26 @@
+# Clockodo OpenAPI specification
+
+`openapi.yaml` is a vendored copy of the Clockodo REST API specification. It
+exists for offline reference, schema-drift detection, and to make upstream
+changes diffable from this repo.
+
+**Do not hand-edit.** Refresh from upstream instead.
+
+## Source
+
+`https://docs.clockodo.com/openapi.yaml`
+
+## Refresh procedure
+
+```bash
+curl -sSL -o specification/openapi.yaml https://docs.clockodo.com/openapi.yaml
+```
+
+Then verify the version line and commit:
+
+```bash
+grep -m1 "^  version:" specification/openapi.yaml
+```
+
+The spec's `info.version` field is an ISO date (e.g. `2026-05-06`) — use that
+as the reference point in commit messages.

--- a/specification/openapi.yaml
+++ b/specification/openapi.yaml
@@ -1,0 +1,19496 @@
+openapi: 3.1.0
+info:
+  title: 'Clockodo API Documentation'
+  description: "# Clockodo REST API\n\nOur API opens Clockodo for other systems. Billing and project management applications or custom shell scripts, for example, are useful mash-ups with Clockodo.\n\nAs a REST API, the interface allows you to query and modify Clockodo data and control the clock via HTTP in JSON format.\n\n## Legacy API Documentation\n\nIf you're still using an earlier version of any of our API endpoints, you can find the corresponding documentation here: [Clockodo Legacy API Documentation](https://www.clockodo.com/api/)\n\nPlease note that this documentation is no longer actively updated. Please update your integrations by May 1, 2026, and migrate to the latest API endpoints documented here to benefit from improved features and ongoing support:\n\n| Deprecated endpoint                          | Successor                                                                                                     |\n|----------------------------------------------|---------------------------------------------------------------------------------------------------------------|\n| api/absences                                 | [api/v4/absences](./#tag/Absence)                                                                             |\n| api/customers                                | [api/v3/customers](./#tag/Customer)                                                                           |\n| api/v2/customers/countProjects               | [api/v3/customers/countProjects](./#tag/Customer/operation/getCustomersCountProjectsV3)                       |\n| api/entries                                  | [api/v2/entries](./#tag/Entry)                                                                                |\n| api/holidaysquota                            | [api/v2/holidaysQuota](./#tag/HolidayQuota)                                                                   |\n| api/lumpsumservices                          | [api/v4/lumpSumServices](./#tag/LumpSumService)                                                               |\n| api/services                                 | [api/v4/services](./#tag/Service)                                                                             |\n| api/users                                    | [api/v3/users](./#tag/User)                                                                                   |\n| api/users/me                                 | [api/v4/users/me](./#tag/User/operation/getUsersMeV4)                                                         |\n| api/v2/absences                              | [api/v4/absences](./#tag/Absence)                                                                             |\n| api/v3/absences                              | [api/v4/absences](./#tag/Absence)                                                                             |\n| api/v2/aggregates/users/me                   | [api/v4/users/me](./#tag/User/operation/getUsersMeV4)                                                         |\n| api/v2/customers                             | [api/v3/customers](./#tag/Customer)                                                                           |\n| api/v2/entriesTexts                          | [api/v3/entriesTexts](./#tag/EntryText)                                                                       |\n| api/holidayscarry                            | [api/v3/holidaysCarry](./#tag/HolidayCarryover)                                                               |\n| api/v2/lumpsumservices                       | [api/v4/lumpSumServices](./#tag/LumpSumService)                                                               |\n| api/v3/lumpsumservices                       | [api/v4/lumpSumServices](./#tag/LumpSumService)                                                               |\n| api/nonbusinessdays                          | [api/v2/nonbusinessDays](./#tag/NonbusinessDay)                                                               |\n| api/nonbusinessgroups                        | [api/v2/nonbusinessGroups](./#tag/NonbusinessGroup)                                                           |\n| api/overtimecarry                            | [api/v3/overtimeCarry](./#tag/OvertimeCarry)                                                                  |\n| api/v2/projects                              | [api/v4/projects](./#tag/Project)                                                                             |\n| api/v2/services                              | [api/v4/services](./#tag/Service)                                                                             |\n| api/v3/services                              | [api/v4/services](./#tag/Service)                                                                             |\n| api/v2/teams                                 | [api/v3/teams](./#tag/Team)                                                                                   |\n| api/v2/users                                 | [api/v3/users](./#tag/User)                                                                                   |\n| api/v2/users/me                              | [api/v4/users/me](./#tag/User/operation/getUsersMeV4)                                                         |\n| api/v2/workTimes/changeRequests/{id}/approve | [api/v3/workTimes/changeRequests/{id}/approve](./#tag/WorkTime/operation/approveWorkTimesChangeRequestByIdV3) |\n\n## URL of the Clockodo API\n\nYou can access our API via the following URL:\n\n```text\nhttps://my.clockodo.com/api/[resource type]\n```\n\nThe resource type represents a class of your data.\n\nOnce you request a specific resource, for example, query information about exactly one entity, you can use the following URL:\n\n```text\nhttps://my.clockodo.com/api/[resource type]/[resource ID]\n```\n\nIn the following sections of this documentation, you will find more detailed descriptions of the available endpoints for each resource type. For example, under [Entry](./#tag/Entry) you will find detailed information on how you can manage time entries in your Clockodo environment.\n\n## HTTP Verbs\n\nTo tell the API which operations you want to perform on the resources, the so-called verbs of the HTTP protocol are used. The following operations are usually possible:\n\n| HTTP Verb                   | Description                                                     |\n|-----------------------------|-----------------------------------------------------------------|\n| `GET`                       | Query a list of all the resources of the selected resource type |\n| `GET` (with resource ID)    | Query exactly one resource                                      |\n| `POST`                      | Create a new resource                                           |\n| `PUT` (with resource ID)    | Update or edit a resource                                       |\n| `DELETE` (with resource ID) | Delete a resource                                               |\n\n## Authentication\n\nEach Clockodo user has his personal API access, which takes into account the user's access rights. You can find your API key under the menu item \"Personal data\" in your Clockodo account.\n\nTo gain access to your data via the API, you must authenticate yourself to the API using the API key. There are two different ways to do this:\n\n**Via the following HTTP headers:**\n\n```http\nX-ClockodoApiUser: [email address]\nX-ClockodoApiKey: [API key]\n```\n\n**Or using the basic authentication of the HTTP protocol:**\n\n```http\nUser: [email address]\nPassword: [API key]\n```\n\n## Client identification\n\nEach request to our API must contain an identification of the calling application, including the email address of a technical contact person. For this, the following HTTP header must be used:\n\n```http\nX-Clockodo-External-Application: [name of application or company];[email address]\n```\n\n**Example:**\n\n```http\nX-Clockodo-External-Application: Clockodo;admin@clockodo.com\n```\n\n## Localization: Language & formats\n\nSome response values of the API are localized. For example, texts describing dates, error messages, etc.  \nIn order to switch between available languages (`en`, `de`, `fr`), use the following HTTP header:\n\n```http\nAccept-Language: en\n```\n\n## Response codes\n\nThe API responds to requests with the status codes of the HTTP protocol. In the event of errors, you will also find additional error information in the response.\n\n| Status Code | Meaning                                                                                                                            |\n| ----------- | ---------------------------------------------------------------------------------------------------------------------------------- |\n| `200`       | OK – The request was successful                                                                                                    |\n| `400`       | Bad Request – The request was defective (e.g. missing parameter)                                                                   |\n| `401`       | Unauthorized – Authentication failed                                                                                               |\n| `403`       | Forbidden – Insufficient access rights for the requested resource                                                                  |\n| `404`       | Not Found – The requested resource was not found                                                                                   |\n| `405`       | Method Not Allowed – The requested endpoint cannot be used                                                                         |\n| `409`       | Conflict – A resource with the data already exists                                                                                 |\n| `422`       | Unprocessable Entity - The server understands the content type but cannot process the instructions (validation or semantic errors) |\n| `429`       | Too Many Requests – Too many requests to an endpoint in a certain period of time                                                   |\n| `500`       | Internal Server Error – An unknown error occurred                                                                                  |\n\n## Rate Limits\n\nTo maintain platform stability, ensure fair usage across all customers, and protect overall performance, the Clockodo API enforces tiered rate limits. If a limit is exceeded, the request is rejected with HTTP 429 (Too Many Requests). You should implement backoff and retry logic.\n\nCurrent default limits per authenticated user:\n\n| Window     | Limit           |\n| ---------- |-----------------|\n| 1 minute   | 900 requests    |\n| 15 minutes | 2,250 requests  |\n| 1 hour     | 4,500 requests  |\n| 1 day      | 20,000 requests |\n\nBest practices:\n\n-   Design idempotent operations so safe retries are possible after 429.\n-   Distribute bursts evenly instead of sending large spikes.\n-   Use pagination and filtering to reduce unnecessary payloads.\n-   Cache stable data (e.g. metadata lists) instead of re-fetching every request.\n-   Only request fields and endpoints actually needed by your workflow.\n\nIf you hit a limit:\n\n1. Respect any Retry-After header if present.\n2. Apply exponential backoff (e.g. 1s, 2s, 4s...) up to a sensible cap.\n3. Reduce concurrency and throttle subsequent batches.\n\nContact support if your sustained legitimate usage regularly requires higher thresholds.\n\n## Page-by-page output\n\nCertain resources such as [entries](./#tag/Entry), [customers](./#tag/Customer) and [projects](./#tag/Project) can return a lot of data. Therefore, a “page-by-page output” is active for these resources, meaning the number of elements returned per call is limited.\n\nYou can use the additional request parameter `page` to access further elements.\n\n```http\npage=[integer]\n```\n\n**Additional content of the response:**\n\n```json\n\"paging\": {\n  \"items_per_page\": [integer],\n  \"current_page\": [integer],\n  \"count_pages\": [integer],\n  \"count_items\": [integer]\n}\n```\n\n## Example calls\n\n**Example: Retrieve all services with cURL using basic authentication:**\n\n```bash\ncurl -v \\\n  -X GET \\\n  -u [email address]:[API key] \\\n  -H 'X-Clockodo-External-Application: [name of application];[email address]' \\\n  'https://my.clockodo.com/api/v4/services'\n```\n\n**Example: Retrieve all services with cURL using authentication via the HTTP header:**\n\n```bash\ncurl -v \\\n  -X GET \\\n  -H 'X-ClockodoApiUser: [email address]' \\\n  -H 'X-ClockodoApiKey: [API key]' \\\n  -H 'X-Clockodo-External-Application: [name of application];[email address]' \\\n  'https://my.clockodo.com/api/v4/services'\n```\n\n**Example: Create a service:**\n\n```bash\ncurl -v \\\n  -X POST \\\n  -H 'X-ClockodoApiUser: [email address]' \\\n  -H 'X-ClockodoApiKey: [API key]' \\\n  -H 'X-Clockodo-External-Application: [name of application];[email address]' \\\n  --data \"name=Test Service\" \\\n  'https://my.clockodo.com/api/v4/services'\n```\n\n# Clockodo Webhooks\n\nWebhooks make it possible to react to events in Clockodo in real time. When a defined event occurs, our system automatically sends an HTTP POST request to a URL you specify.  \nThis allows you to trigger your own workflows or automate and synchronize external systems.\n\n## Supported Webhook Events\n\nSupported webhook events are documented under [Webhooks](./#tag/Webhook).\n\n## Creating and Editing a Webhook\n\nYou can create a new webhook or edit an existing one via the _Webhooks_ section in the Clockodo menu.  \nSimply select the desired event (see table above), enter the target URL and a token.\n\n### Webhook Validation\n\nA webhook must be validated when it is initially created or its URL is changed.  \nThis is as a security measure and ensures that you control the specified target URL.\n\nTo validate the webhook, Clockodo sends a POST request to the URL you provided with the following payload:\n\n```json\n{\n    \"secret\": \"XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX\"\n}\n```\n\nEnter the received secret into the corresponding input field in Clockodo.\n\n## Webhook Payload\n\nEach webhook call is sent as an HTTP POST request in JSON format to the configured URL. The general structure is as follows:\n\n```json\n{\n    \"subscription_id\": 42,\n    \"company_id\": 1337,\n    \"occurred_at\": \"1986-05-10T17:02:00Z\",\n    \"payload\": {\n        \"team\": {\n            \"id\": 9001\n        }\n    },\n    \"event_name\": \"team.updated\",\n    \"token\": \"My_Sup3r_T0k3n\"\n}\n```\n\n-   `subscription_id`  \n    Unique ID of the webhook subscription\n\n-   `company_id`  \n    ID of your company in Clockodo\n\n-   `occurred_at`  \n    Timestamp of the event (ISO 8601, UTC)\n\n-   `event_name`  \n    Type of the triggered event\n\n-   `payload`  \n    Contains the affected entity and its ID\n\n-   `token`  \n    The token you defined when setting up the webhook (used to authenticate incoming requests)\n\nWe only transmit the ID of the created, modified, or deleted entity. **We don't transmit full datasets or deltas**.\n\nThis approach has several advantages:\n\n-   **Data security**  \n    No sensitive or extensive data is transmitted unnecessarily.\n\n-   **Actuality of the data**  \n    After receiving a webhook event, you can **retrieve the current and complete data** via API.  \n    This prevents inconsistencies that could arise due to parallel changes or delays.\n\n-   **Reduced risk of errors**  \n    For complex or rapidly changing data structures, querying the current state is often more reliable than processing potentially outdated snapshots.\n\n-   **Flexibility**  \n    Your system can decide when and to what extent it needs additional information.\n\n## Best Practices and Recommendations\n\n-   **Event validation**  \n    Always verify the token and structure of incoming webhook data.\n\n-   **Idempotency**  \n    Ensure your systems can correctly handle duplicate or repeated events.\n\n-   **Logging**  \n    Log incoming webhook calls for debugging and traceability purposes.\n"
+  termsOfService: 'https://www.clockodo.com/en/terms-and-conditions/'
+  contact:
+    name: 'Clockodo support'
+    url: 'https://www.clockodo.com/en/about-us/'
+    email: support@clockodo.com
+  version: '2026-05-06'
+  x-logo:
+    url: /clockodo-logo.svg
+    altText: 'Clockodo Logo'
+    backgroundColor: '#3d2a5a'
+servers:
+  -
+    url: 'https://my.clockodo.com/api'
+paths:
+  /register:
+    post:
+      tags:
+        - Register
+      operationId: createRegister
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - companies_name
+                - name
+                - email
+              properties:
+                companies_name:
+                  type: string
+                  maxLength: 100
+                name:
+                  type: string
+                  maxLength: 100
+                email:
+                  type: string
+                  format: email
+                rfs:
+                  description: 'Name of the external application from which the registration is made'
+                  type: [string, 'null']
+                bs:
+                  description: 'Preselected billing application'
+                  type: [string, 'null']
+                gtc_agreed:
+                  description: 'Terms of Clockodo were accepted'
+                  type: [string, 'null']
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RegisterV1'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /targethours:
+    get:
+      tags:
+        - TargetHour
+      operationId: getTargethours
+      parameters:
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              -
+                type: array
+                items:
+                  type: integer
+                  maximum: 500
+              -
+                type: integer
+                maximum: 500
+              -
+                type: string
+                format: csv-string
+                x-csv-element-schema:
+                  type: integer
+                  maximum: 500
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - targethours
+                properties:
+                  targethours: { type: array, items: { $ref: '#/components/schemas/TargetHourV1' } }
+                type: object
+      deprecated: false
+    post:
+      tags:
+        - TargetHour
+      operationId: createTargethour
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - users_id
+                - type
+                - date_since
+                - date_until
+                - compensation_monthly
+              properties:
+                users_id:
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/TargetHourType'
+                date_since:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                date_until:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                monday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                tuesday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                wednesday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                thursday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                friday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                saturday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                sunday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                monthly_target:
+                  type: number
+                  format: float
+                  maximum: 744
+                  minimum: 0
+                workday_monday:
+                  type: boolean
+                workday_tuesday:
+                  type: boolean
+                workday_wednesday:
+                  type: boolean
+                workday_thursday:
+                  type: boolean
+                workday_friday:
+                  type: boolean
+                workday_saturday:
+                  type: boolean
+                workday_sunday:
+                  type: boolean
+                compensation_daily:
+                  description: 'Automatic time compensation per day in minutes'
+                  type: integer
+                  maximum: 1440
+                  minimum: 0
+                compensation_monthly:
+                  description: 'Compensation for monthly target hours in minutes'
+                  type: integer
+                  maximum: 744
+                  minimum: 0
+                holiday_fixed_credit:
+                  type: integer
+                  enum: [0, 1]
+                surcharge_models_id:
+                  type: [integer, 'null']
+                  minimum: 1
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - targethoursRow
+                properties:
+                  targethoursRow: { $ref: '#/components/schemas/TargetHourV1' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/targethours/{id}':
+    get:
+      tags:
+        - TargetHour
+      operationId: getTargethourById
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - targethoursRow
+                properties:
+                  targethoursRow: { $ref: '#/components/schemas/TargetHourV1' }
+                type: object
+      deprecated: false
+    put:
+      tags:
+        - TargetHour
+      operationId: updateTargethourById
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - date_since
+              properties:
+                type:
+                  $ref: '#/components/schemas/TargetHourType'
+                date_since:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                date_until:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                monday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                tuesday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                wednesday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                thursday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                friday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                saturday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                sunday:
+                  type: number
+                  format: float
+                  maximum: 24
+                  minimum: 0
+                monthly_target:
+                  type: number
+                  format: float
+                  maximum: 744
+                  minimum: 0
+                workday_monday:
+                  type: boolean
+                workday_tuesday:
+                  type: boolean
+                workday_wednesday:
+                  type: boolean
+                workday_thursday:
+                  type: boolean
+                workday_friday:
+                  type: boolean
+                workday_saturday:
+                  type: boolean
+                workday_sunday:
+                  type: boolean
+                compensation_daily:
+                  description: 'Compensation for daily target hours in minutes'
+                  type: integer
+                  maximum: 1440
+                  minimum: 0
+                compensation_monthly:
+                  description: 'Compensation for monthly target hours in minutes'
+                  type: integer
+                  maximum: 744
+                  minimum: 0
+                holiday_fixed_credit:
+                  type: integer
+                  enum: [0, 1]
+                surcharge_models_id:
+                  type: [integer, 'null']
+                  minimum: 1
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - targethoursRow
+                properties:
+                  targethoursRow: { $ref: '#/components/schemas/TargetHourV1' }
+                type: object
+      deprecated: false
+    delete:
+      tags:
+        - TargetHour
+      operationId: deleteTargethourById
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+      deprecated: false
+  /userreports:
+    get:
+      tags:
+        - UserReport
+      operationId: getUserreports
+      parameters:
+        -
+          name: type
+          in: query
+          description: "Possible values:\n- `0`: Only for year (default)\n- `1`: For year and months\n- `2`: For year, months and weeks\n- `3`: For year, months, weeks and days\n- `4`: For year, months, weeks and days; including start and end times and breaks"
+          required: false
+          schema:
+            $ref: '#/components/schemas/UserReportType'
+        -
+          name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            maximum: 2027
+            minimum: 1910
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - userreports
+                properties:
+                  userreports: { type: array, items: { $ref: '#/components/schemas/UserReportV1' } }
+                type: object
+      deprecated: false
+  '/userreports/{id}':
+    get:
+      tags:
+        - UserReport
+      operationId: getUserreportById
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+        -
+          name: type
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/UserReportType'
+        -
+          name: year
+          in: query
+          required: true
+          schema:
+            type: integer
+            maximum: 2027
+            minimum: 1910
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - userreport
+                properties:
+                  userreport: { $ref: '#/components/schemas/UserReportV1' }
+                type: object
+      deprecated: false
+  /v2/accessGroups:
+    get:
+      tags:
+        - AccessGroup
+      operationId: getAccessGroupsV2
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/AccessGroupV2' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - AccessGroup
+      operationId: createAccessGroupV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                users_ids:
+                  description: 'IDs of the access group members'
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 500
+                  minItems: 0
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/AccessGroupV2' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAccessGroupsV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/accessGroups/{accessGroupsId}/customers':
+    put:
+      tags:
+        - AccessGroupAccess
+      operationId: updateAccessGroupsCustomerByAccessGroupsIdV2
+      parameters:
+        -
+          name: accessGroupsId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+                - type
+                - value
+              properties:
+                id:
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/AccessType'
+                value:
+                  $ref: '#/components/schemas/AccessValue'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/accessGroups/{accessGroupsId}/customers/general':
+    put:
+      tags:
+        - AccessGroupAccess
+      operationId: updateAccessGroupsCustomersGeneralByAccessGroupsIdV2
+      parameters:
+        -
+          name: accessGroupsId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - value
+              properties:
+                type:
+                  $ref: '#/components/schemas/AccessType'
+                value:
+                  $ref: '#/components/schemas/AccessValue'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAccessGroupsCustomersGeneralV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/accessGroups/{accessGroupsId}/customersProjects':
+    get:
+      tags:
+        - AccessGroupAccess
+      operationId: getAccessGroupsCustomersProjectByAccessGroupsIdV2
+      parameters:
+        -
+          name: accessGroupsId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/accessGroups/{accessGroupsId}/projects':
+    put:
+      tags:
+        - AccessGroupAccess
+      operationId: updateAccessGroupsProjectByAccessGroupsIdV2
+      parameters:
+        -
+          name: accessGroupsId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+                - type
+                - value
+              properties:
+                id:
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/AccessType'
+                value:
+                  $ref: '#/components/schemas/ApiAccessGroupsProjectsV2_AccessValueForPut'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/accessGroups/{accessGroupsId}/services':
+    get:
+      tags:
+        - AccessGroupAccess
+      operationId: getAccessGroupsServiceByAccessGroupsIdV2
+      parameters:
+        -
+          name: accessGroupsId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/services_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - AccessGroupAccess
+      operationId: updateAccessGroupsServiceByAccessGroupsIdV2
+      parameters:
+        -
+          name: accessGroupsId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+                - type
+                - value
+              properties:
+                id:
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/ApiAccessGroupsServicesV2_AccessTypeForPut'
+                value:
+                  $ref: '#/components/schemas/ApiAccessGroupsServicesV2_AccessValueForPut'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/services_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/accessGroups/{accessGroupsId}/services/general':
+    put:
+      tags:
+        - AccessGroupAccess
+      operationId: updateAccessGroupsServicesGeneralByAccessGroupsIdV2
+      parameters:
+        -
+          name: accessGroupsId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - value
+              properties:
+                type:
+                  $ref: '#/components/schemas/ApiAccessGroupsServicesGeneralV2_AccessTypeForPut'
+                value:
+                  $ref: '#/components/schemas/AccessValue'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/services_access_v2'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAccessGroupsServicesGeneralV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/accessGroups/{id}':
+    get:
+      tags:
+        - AccessGroup
+      operationId: getAccessGroupByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/AccessGroupV2' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - AccessGroup
+      operationId: updateAccessGroupByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                users_ids:
+                  description: 'IDs of the access group members'
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 500
+                  minItems: 0
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/AccessGroupV2' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAccessGroupsV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - AccessGroup
+      operationId: deleteAccessGroupByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAccessGroupsV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v2/aggregates/users/me:
+    get:
+      tags:
+        - AggregatesUsersMe
+      operationId: getAggregatesUsersMeV2
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AggregatesUsersMeV2'
+      deprecated: true
+  /v2/clock:
+    get:
+      tags:
+        - Clock
+      summary: 'Get currently running entry'
+      operationId: getClockV2
+      parameters:
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClockV2'
+      deprecated: false
+    post:
+      tags:
+        - Clock
+      summary: 'Start clock'
+      operationId: createClockV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - customers_id
+                - services_id
+              properties:
+                customers_id:
+                  type: integer
+                  minimum: 1
+                services_id:
+                  type: integer
+                  minimum: 1
+                billable:
+                  oneOf: [{ $ref: '#/components/schemas/Billable' }, { type: 'null' }]
+                duration_transfer:
+                  type: [integer, 'null']
+                  minimum: 0
+                projects_id:
+                  type: [integer, 'null']
+                  minimum: 0
+                subprojects_id:
+                  type: [integer, 'null']
+                  minimum: 0
+                text:
+                  type: [string, 'null']
+                  maxLength: 1000
+                time_since:
+                  type: [string, 'null']
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                users_id:
+                  type: [integer, 'null']
+                  minimum: 1
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClockStartStopV2'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/clock/{id}':
+    put:
+      tags:
+        - Clock
+      summary: 'Change duration'
+      operationId: updateClockByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                time_since:
+                  type: [string, 'null']
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                time_since_before:
+                  type: [string, 'null']
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                time_until_before:
+                  type: [string, 'null']
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                duration:
+                  type: [integer, 'null']
+                  minimum: 0
+                duration_before:
+                  type: [integer, 'null']
+                  minimum: 0
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClockDurationV2'
+      deprecated: false
+    delete:
+      tags:
+        - Clock
+      summary: 'Stop clock'
+      operationId: deleteClockByIdV2
+      parameters:
+        -
+          name: away
+          in: query
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            minimum: 0
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+        -
+          name: start_new
+          in: query
+          required: false
+          schema:
+            type:
+              - boolean
+              - 'null'
+        -
+          name: time_until
+          in: query
+          required: false
+          schema:
+            type:
+              - string
+              - 'null'
+            format: date-time
+            example: '2023-02-28T12:00:00Z'
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+            minimum: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClockStartStopV2'
+      deprecated: false
+  /v2/entries:
+    get:
+      tags:
+        - Entry
+      operationId: getEntriesV2
+      parameters:
+        -
+          name: calc_also_revenues_for_projects_with_hard_budget
+          in: query
+          required: false
+          schema:
+            type:
+              - boolean
+              - 'null'
+        -
+          name: enhanced_list
+          in: query
+          required: false
+          schema:
+            type:
+              - boolean
+              - 'null'
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              billable:
+                oneOf:
+                  - { $ref: '#/components/schemas/Billable' }
+                  - { type: 'null' }
+              budget_type:
+                oneOf:
+                  - { $ref: '#/components/schemas/BudgetOption' }
+                  - { type: 'null' }
+              customers_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+              lumpsum_services_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+              projects_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+              services_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+              subprojects_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+              text:
+                type:
+                  - string
+                  - 'null'
+              texts_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+              users_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+            type:
+              - object
+              - 'null'
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 1000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: time_since
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: '2023-02-28T12:00:00Z'
+        -
+          name: time_until
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: '2023-02-28T12:00:00Z'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - entries
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  entries: { type: array, items: { $ref: '#/components/schemas/EntryV2' } }
+                type: object
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: false
+    post:
+      tags:
+        - Entry
+      operationId: createEntryV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - customers_id
+                - billable
+              properties:
+                time_since:
+                  type: string
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                time_until:
+                  type: string
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                customers_id:
+                  type: integer
+                  minimum: 0
+                billable:
+                  $ref: '#/components/schemas/BillableWithoutBilled'
+                projects_id:
+                  type: integer
+                  minimum: 0
+                subprojects_id:
+                  type: integer
+                  minimum: 0
+                services_id:
+                  type: integer
+                  minimum: 0
+                lumpsum_services_id:
+                  type: integer
+                  minimum: 0
+                users_id:
+                  type: integer
+                  minimum: 0
+                clocked_offline:
+                  type: boolean
+                duration:
+                  type: integer
+                  minimum: 0
+                lumpsum:
+                  type: number
+                  format: float
+                  minimum: 0
+                hourly_rate:
+                  type: number
+                  format: float
+                  minimum: 0
+                lumpsum_services_amount:
+                  type: number
+                  format: float
+                  minimum: 0
+                text:
+                  type: string
+                time_clocked_since:
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - entry
+                properties:
+                  entry: { $ref: '#/components/schemas/EntryV2' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: false
+  '/v2/entries/{id}':
+    get:
+      tags:
+        - Entry
+      operationId: getEntryByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - entry
+                properties:
+                  entry: { $ref: '#/components/schemas/EntryV2' }
+                type: object
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: false
+    put:
+      tags:
+        - Entry
+      operationId: updateEntryByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                time_since:
+                  type: string
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                time_until:
+                  type: string
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                customers_id:
+                  type: integer
+                  minimum: 0
+                billable:
+                  $ref: '#/components/schemas/Billable'
+                projects_id:
+                  type: integer
+                  minimum: 0
+                subprojects_id:
+                  type: integer
+                  minimum: 0
+                services_id:
+                  type: integer
+                  minimum: 0
+                lumpsum_services_id:
+                  type: integer
+                  minimum: 0
+                users_id:
+                  type: integer
+                  minimum: 0
+                duration:
+                  type: integer
+                  minimum: 0
+                lumpsum:
+                  type: number
+                  format: float
+                  minimum: 0
+                hourly_rate:
+                  type: number
+                  format: float
+                  minimum: 0
+                lumpsum_services_amount:
+                  type: number
+                  format: float
+                  minimum: 0
+                text:
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - entry
+                properties:
+                  entry: { $ref: '#/components/schemas/EntryV2' }
+                type: object
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: false
+    delete:
+      tags:
+        - Entry
+      operationId: deleteEntryByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: false
+  /v2/entrygroups:
+    get:
+      tags:
+        - EntryGroup
+      operationId: getEntrygroupsV2
+      parameters:
+        -
+          name: calc_also_revenues_for_projects_with_hard_budget
+          in: query
+          required: false
+          schema:
+            type:
+              - boolean
+              - 'null'
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              billable:
+                oneOf:
+                  - { $ref: '#/components/schemas/BillableDistinct' }
+                  - { type: 'null' }
+              budget_type:
+                oneOf:
+                  - { $ref: '#/components/schemas/BudgetOption' }
+                  - { type: 'null' }
+              customers_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              lumpsum_services_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              projects_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              services_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              subprojects_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              teams_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              text:
+                type:
+                  - string
+                  - 'null'
+              texts_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              users_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+            type:
+              - object
+              - 'null'
+        -
+          name: grouping
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Grouping'
+            minItems: 1
+        -
+          name: prepend_customer_to_project_name
+          in: query
+          required: false
+          schema:
+            type:
+              - boolean
+              - 'null'
+        -
+          name: round_to_minutes
+          in: query
+          required: false
+          schema:
+            type:
+              - integer
+              - 'null'
+        -
+          name: time_since
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: '2023-02-28T12:00:00Z'
+        -
+          name: time_until
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: '2023-02-28T12:00:00Z'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - groups
+                properties:
+                  groups: { type: array, items: { $ref: '#/components/schemas/EntryGroupV2' } }
+                type: object
+      deprecated: false
+    put:
+      tags:
+        - EntryGroup
+      operationId: updateEntrygroupV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - time_since
+                - time_until
+              properties:
+                time_since:
+                  type: string
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                time_until:
+                  type: string
+                  format: date-time
+                  example: '2023-02-28T12:00:00Z'
+                users_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                customers_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                projects_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                subprojects_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                services_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                lumpsum_services_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                billable:
+                  oneOf: [{ $ref: '#/components/schemas/BillableDistinct' }, { type: 'null' }]
+                text:
+                  type: [string, 'null']
+                hourly_rate:
+                  type: [number, 'null']
+                  format: float
+                  minimum: 0
+                confirm_key:
+                  description: 'For safety, the api will respond with a confirmation key with which you have to request once again in order to confirm your edit action'
+                  type: string
+                filter:
+                  properties: { billable: { oneOf: [{ $ref: '#/components/schemas/BillableDistinct' }, { type: 'null' }] }, budget_type: { oneOf: [{ $ref: '#/components/schemas/BudgetOption' }, { type: 'null' }] }, customers_id: { type: [integer, 'null'], minimum: 1 }, lumpsum_services_id: { type: [integer, 'null'], minimum: 1 }, projects_id: { type: [integer, 'null'], minimum: 1 }, services_id: { type: [integer, 'null'], minimum: 1 }, subprojects_id: { type: [integer, 'null'], minimum: 1 }, teams_id: { type: [integer, 'null'], minimum: 1 }, text: { type: [string, 'null'] }, texts_id: { type: [integer, 'null'], minimum: 1 }, users_id: { type: [integer, 'null'], minimum: 1 } }
+                  type: [object, 'null']
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - { $ref: '#/components/schemas/EntryGroupUpdateV2' }
+                  - { $ref: '#/components/schemas/EntryGroupConfirmUpdateV2' }
+      deprecated: false
+    delete:
+      tags:
+        - EntryGroup
+      operationId: deleteEntrygroupV2
+      parameters:
+        -
+          name: confirm_key
+          in: query
+          required: false
+          schema:
+            type: string
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              billable:
+                oneOf:
+                  - { $ref: '#/components/schemas/BillableDistinct' }
+                  - { type: 'null' }
+              budget_type:
+                oneOf:
+                  - { $ref: '#/components/schemas/BudgetOption' }
+                  - { type: 'null' }
+              customers_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              lumpsum_services_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              projects_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              services_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              subprojects_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              teams_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              text:
+                type:
+                  - string
+                  - 'null'
+              texts_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+              users_id:
+                type:
+                  - integer
+                  - 'null'
+                minimum: 1
+            type:
+              - object
+              - 'null'
+        -
+          name: time_since
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: '2023-02-28T12:00:00Z'
+        -
+          name: time_until
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date-time
+            example: '2023-02-28T12:00:00Z'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - { $ref: '#/components/schemas/EntryGroupUpdateV2' }
+                  - { $ref: '#/components/schemas/EntryGroupConfirmUpdateV2' }
+      deprecated: false
+  '/v2/favorites/{id}/start':
+    post:
+      tags:
+        - Favorite
+      operationId: createFavoritesStartByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClockStartStopV2'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v2/holidaysQuota:
+    get:
+      tags:
+        - HolidayQuota
+      operationId: getHolidaysQuotaV2
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              users_id:
+                type: integer
+                minimum: 1
+              year:
+                type: integer
+                maximum: 2037
+                minimum: 2000
+            type: object
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: year
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 2037
+            minimum: 2000
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/HolidaysQuotaV2' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - HolidayQuota
+      operationId: createHolidaysQuotaV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - users_id
+                - year_since
+                - count
+              properties:
+                users_id:
+                  type: integer
+                  minimum: 1
+                year_since:
+                  description: 'Year from which on the vacation quota setting applies.'
+                  type: integer
+                  format: YYYY
+                  maximum: 2037
+                  minimum: 2000
+                  example: 2023
+                year_until:
+                  description: 'Year until the vacation quota setting applies.'
+                  type: [integer, 'null']
+                  format: YYYY
+                  maximum: 2037
+                  minimum: 2000
+                  example: 2023
+                count:
+                  description: 'Amount of vacation days.'
+                  type: number
+                  format: float
+                  maximum: 365
+                  minimum: 0
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/HolidaysQuotaV2' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiHolidaysQuotaV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/holidaysQuota/{id}':
+    get:
+      tags:
+        - HolidayQuota
+      operationId: getHolidaysQuotaByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/HolidaysQuotaV2' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - HolidayQuota
+      operationId: updateHolidaysQuotaByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                year_since:
+                  description: 'Year from which on the vacation quota setting applies.'
+                  type: integer
+                  format: YYYY
+                  maximum: 2037
+                  minimum: 2000
+                  example: 2023
+                year_until:
+                  description: 'Year until the vacation quota setting applies.'
+                  type: [integer, 'null']
+                  format: YYYY
+                  maximum: 2037
+                  minimum: 2000
+                  example: 2023
+                count:
+                  description: 'Amount of vacation days.'
+                  type: number
+                  format: float
+                  maximum: 365
+                  minimum: 0
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/HolidaysQuotaV2' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiHolidaysQuotaV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - HolidayQuota
+      operationId: deleteHolidaysQuotaByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiHolidaysQuotaV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/individualUserAccess/{usersId}/clear':
+    post:
+      tags:
+        - IndividualUserAccess
+      operationId: clearIndividualUserAccessByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/individualUserAccess/{usersId}/customers':
+    put:
+      tags:
+        - IndividualUserAccess
+      operationId: updateIndividualUserAccessCustomerByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+                - type
+                - value
+              properties:
+                id:
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/AccessType'
+                value:
+                  $ref: '#/components/schemas/AccessValue'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/individualUserAccess/{usersId}/customers/general':
+    put:
+      tags:
+        - IndividualUserAccess
+      operationId: updateIndividualUserAccessCustomersGeneralByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - value
+              properties:
+                type:
+                  $ref: '#/components/schemas/AccessType'
+                value:
+                  $ref: '#/components/schemas/AccessValue'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiIndividualUserAccessCustomersGeneralV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/individualUserAccess/{usersId}/customersProjects':
+    get:
+      tags:
+        - IndividualUserAccess
+      operationId: getIndividualUserAccessCustomersProjectByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/individualUserAccess/{usersId}/projects':
+    put:
+      tags:
+        - IndividualUserAccess
+      operationId: updateIndividualUserAccessProjectByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+                - type
+                - value
+              properties:
+                id:
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/AccessType'
+                value:
+                  $ref: '#/components/schemas/ApiAccessGroupsProjectsV2_AccessValueForPut'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/customer_projects_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/individualUserAccess/{usersId}/services':
+    get:
+      tags:
+        - IndividualUserAccess
+      operationId: getIndividualUserAccessServiceByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/services_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - IndividualUserAccess
+      operationId: updateIndividualUserAccessServiceByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+                - type
+                - value
+              properties:
+                id:
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/ApiAccessGroupsServicesV2_AccessTypeForPut'
+                value:
+                  $ref: '#/components/schemas/ApiAccessGroupsServicesV2_AccessValueForPut'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/services_access_v2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/individualUserAccess/{usersId}/services/general':
+    put:
+      tags:
+        - IndividualUserAccess
+      operationId: updateIndividualUserAccessServicesGeneralByUsersIdV2
+      parameters:
+        -
+          name: usersId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+                - value
+              properties:
+                type:
+                  $ref: '#/components/schemas/ApiAccessGroupsServicesGeneralV2_AccessTypeForPut'
+                value:
+                  $ref: '#/components/schemas/AccessValue'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/services_access_v2'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiIndividualUserAccessServicesGeneralV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v2/nonbusinessDays:
+    get:
+      tags:
+        - NonbusinessDay
+      operationId: getNonbusinessDaysV2
+      parameters:
+        -
+          name: nonbusiness_group_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              -
+                type: array
+                items:
+                  type: integer
+                  minimum: 1
+                maxItems: 500
+              -
+                type: integer
+                minimum: 1
+              -
+                type: string
+                format: csv-string
+                x-csv-element-schema:
+                  type: integer
+                  minimum: 1
+        -
+          name: year
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 2037
+            minimum: 2000
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/NonbusinessDayV2' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - NonbusinessDay
+      operationId: createNonbusinessDayV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - nonbusiness_group_id
+                - type
+                - name
+              properties:
+                nonbusiness_group_id:
+                  description: 'Default: Company default nonbusiness group'
+                  type: integer
+                  minimum: 1
+                type:
+                  $ref: '#/components/schemas/NonbusinessDayType'
+                name:
+                  type: string
+                  maxLength: 100
+                half_day:
+                  type: boolean
+                surcharge_special:
+                  type: boolean
+                special_id:
+                  type: integer
+                  minimum: 1
+                day:
+                  type: integer
+                  maximum: 31
+                  minimum: 1
+                month:
+                  type: integer
+                  maximum: 12
+                  minimum: 1
+                year:
+                  type: integer
+                  maximum: 2037
+                  minimum: 2000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/NonbusinessDayV2' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiNonbusinessDaysV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/nonbusinessDays/{id}':
+    get:
+      tags:
+        - NonbusinessDay
+      operationId: getNonbusinessDayByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+        -
+          name: year
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 2037
+            minimum: 2000
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/NonbusinessDayV2' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - NonbusinessDay
+      operationId: updateNonbusinessDayByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                type:
+                  $ref: '#/components/schemas/NonbusinessDayType'
+                name:
+                  type: string
+                  maxLength: 100
+                half_day:
+                  type: boolean
+                surcharge_special:
+                  type: boolean
+                special_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                day:
+                  type: [integer, 'null']
+                  maximum: 31
+                  minimum: 1
+                month:
+                  type: [integer, 'null']
+                  maximum: 12
+                  minimum: 1
+                year:
+                  type: [integer, 'null']
+                  maximum: 2037
+                  minimum: 2000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/NonbusinessDayV2' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiNonbusinessDaysV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - NonbusinessDay
+      operationId: deleteNonbusinessDayByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiNonbusinessDaysV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v2/nonbusinessGroups:
+    get:
+      tags:
+        - NonbusinessGroup
+      operationId: getNonbusinessGroupsV2
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/NonbusinessGroupV2' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - NonbusinessGroup
+      operationId: createNonbusinessGroupV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                preset:
+                  type: string
+                  enum: ['']
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/NonbusinessGroupV2' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiNonbusinessGroupsV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/nonbusinessGroups/{id}':
+    get:
+      tags:
+        - NonbusinessGroup
+      operationId: getNonbusinessGroupByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/NonbusinessGroupV2' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - NonbusinessGroup
+      operationId: updateNonbusinessGroupByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/NonbusinessGroupV2' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiNonbusinessGroupsV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - NonbusinessGroup
+      operationId: deleteNonbusinessGroupByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiNonbusinessGroupsV2Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/projects/{id}/createNextInterval':
+    post:
+      tags:
+        - Project
+      operationId: createProjectsCreateNextIntervalByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/SubprojectV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v2/subscription:
+    get:
+      tags:
+        - Subscription
+      operationId: getSubscriptionV2
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/subscription_v2' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/users/{id}/access/customers-projects':
+    get:
+      tags:
+        - User
+      summary: 'Query access rights for customers and projects'
+      operationId: getUsersAccessCustomersProjectByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersAccessCustomersProjectV2'
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/users/{id}/access/services':
+    get:
+      tags:
+        - User
+      summary: 'Query access rights for services'
+      operationId: getUsersAccessServiceByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UsersAccessServiceV2'
+      deprecated: false
+  /v2/usersNonbusinessDays:
+    get:
+      tags:
+        - UserNonbusinessDay
+      operationId: getUsersNonbusinessDaysV2
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              users_id:
+                oneOf:
+                  - { type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }
+                  - { type: integer, minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 100
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: year
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 2037
+            minimum: 2000
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/UsersNonbusinessDayV2' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v2/workTimes:
+    get:
+      tags:
+        - WorkTime
+      operationId: getWorkTimesV2
+      parameters:
+        -
+          name: date_since
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+            example: '2023-02-28'
+        -
+          name: date_until
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+            example: '2023-02-28'
+        -
+          name: users_id
+          in: query
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - work_time_days
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  work_time_days: { type: array, items: { $ref: '#/components/schemas/WorkTimeV2' } }
+                type: object
+      deprecated: false
+  /v2/workTimes/changeRequests:
+    get:
+      tags:
+        - WorkTime
+      operationId: getWorkTimesChangeRequestsV2
+      parameters:
+        -
+          name: date_since
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+            example: '2023-02-28'
+        -
+          name: date_until
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+            example: '2023-02-28'
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 1000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: scope
+          in: query
+          description: 'Filter by scope, to get change requests that are pending approval or declined.'
+          required: false
+          schema:
+            $ref: '#/components/schemas/ChangeRequestScope'
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortIdDate'
+        -
+          name: status
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/ChangeRequestStatus'
+        -
+          name: teams_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              -
+                type: array
+                items:
+                  type: [integer, 'null']
+                  minimum: 0
+                maxItems: 500
+              -
+                type:
+                  - integer
+                  - 'null'
+                minimum: 0
+              -
+                type: string
+                format: csv-string
+                x-csv-element-schema:
+                  type: [integer, 'null']
+                  minimum: 0
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - change_requests
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  change_requests: { type: array, items: { $ref: '#/components/schemas/WorkTimesChangeRequestV2' } }
+                type: object
+      deprecated: false
+    post:
+      tags:
+        - WorkTime
+      summary: 'Creates a new change request for work times.'
+      description: "There can only be one pending change request per user and day.\nBy creating another change request for a day which already has a pending one,\nthe existing change request will be overwritten.\nIf a change request is submitted for a day on which the user is allowed to edit work times without a change request,\nthe changes are approved automatically and applied to the day's work times."
+      operationId: createWorkTimesChangeRequestV2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - date
+                - users_id
+                - changes
+              properties:
+                date:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                users_id:
+                  type: integer
+                  minimum: 1
+                changes:
+                  type: array
+                  items: { properties: { time_since: { type: string, format: date-time, example: '2023-02-28T12:00:00Z' }, time_until: { type: string, format: date-time, example: '2023-02-28T12:00:00Z' }, type: { $ref: '#/components/schemas/ChangeRequestIntervalType' } }, type: object }
+                  minItems: 1
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkTimesChangeRequestPostV2'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v2/workTimes/changeRequests/{id}':
+    delete:
+      tags:
+        - WorkTime
+      summary: 'Declined change requests cannot be deleted'
+      operationId: deleteWorkTimesChangeRequestByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkTimesChangeRequestDeleteV2'
+      deprecated: false
+  '/v2/workTimes/changeRequests/{id}/approve':
+    post:
+      tags:
+        - WorkTime
+      operationId: approveWorkTimesChangeRequestByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - change_request
+                properties:
+                  change_request: { type: [object, 'null'] }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: true
+  '/v2/workTimes/changeRequests/{id}/decline':
+    post:
+      tags:
+        - WorkTime
+      operationId: createWorkTimesChangeRequestsDeclineByIdV2
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkTimesChangeRequestsDeclineV2'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: true
+  /v3/customers:
+    get:
+      tags:
+        - Customer
+      operationId: getCustomersV3
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              fulltext:
+                type: string
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 5000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CustomerProjectScope'
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortIdNameActive'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/CustomerV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - Customer
+      operationId: createCustomerV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                active:
+                  type: boolean
+                bill_service_id:
+                  description: 'Can only be set by administrators or workers with elevated access `manage_customers_and_projects` and if a billing application with customers support is linked up'
+                  type: [string, 'null']
+                  maxLength: 50
+                billable_default:
+                  type: boolean
+                color:
+                  oneOf: [{ $ref: '#/components/schemas/CustomerColor', description: "Possible values:\n- `1`: BloodOrange\n- `2`: Sunflower\n- `3`: LightGreen\n- `4`: Caribbean\n- `5`: Sky\n- `6`: BrandBlue\n- `7`: BluePurple\n- `8`: Magenta\n- `9`: ChewingGum" }, { type: 'null' }]
+                  description: "Possible values:\n- `1`: BloodOrange\n- `2`: Sunflower\n- `3`: LightGreen\n- `4`: Caribbean\n- `5`: Sky\n- `6`: BrandBlue\n- `7`: BluePurple\n- `8`: Magenta\n- `9`: ChewingGum"
+                name:
+                  type: string
+                  maxLength: 100
+                note:
+                  description: 'Can only be set by administrators or workers with elevated access `manage_customers_and_projects`'
+                  type: [string, 'null']
+                  maxLength: 1000
+                number:
+                  description: 'Freely selectable number for the customer'
+                  type: [string, 'null']
+                  maxLength: 50
+                service_assignments:
+                  description: 'Restrict to services assigned to this customer. Can only be set by administrators or workers with elevated access `manage_customers_and_projects`'
+                  oneOf: [{ type: array, items: { type: integer, minimum: 1 }, x-requires_permission: manage_services }, { type: integer, minimum: 1 }, { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }]
+                  x-requires_permission: manage_services
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/CustomerV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiCustomersV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/customers/countProjects:
+    get:
+      tags:
+        - Customer
+      operationId: getCustomersCountProjectsV3
+      parameters:
+        -
+          name: customers_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              -
+                type: array
+                items:
+                  type: integer
+                  minimum: 0
+                maxItems: 500
+              -
+                type: integer
+                minimum: 0
+              -
+                type: string
+                format: csv-string
+                x-csv-element-schema:
+                  type: integer
+                  minimum: 0
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CustomerProjectScope'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/CustomerCountProjectsV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/customers/{id}':
+    get:
+      tags:
+        - Customer
+      operationId: getCustomerByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/CustomerV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - Customer
+      operationId: updateCustomerByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                active:
+                  type: boolean
+                bill_service_id:
+                  description: 'Can only be set by administrators or workers with elevated access `manage_customers_and_projects` and if a billing application with customers support is linked up'
+                  type: [string, 'null']
+                  maxLength: 50
+                billable_default:
+                  type: boolean
+                color:
+                  $ref: '#/components/schemas/CustomerColor'
+                  description: "Possible values:\n- `1`: BloodOrange\n- `2`: Sunflower\n- `3`: LightGreen\n- `4`: Caribbean\n- `5`: Sky\n- `6`: BrandBlue\n- `7`: BluePurple\n- `8`: Magenta\n- `9`: ChewingGum"
+                name:
+                  type: string
+                  maxLength: 100
+                note:
+                  description: 'Can only be set by administrators or workers with elevated access `manage_customers_and_projects`'
+                  type: [string, 'null']
+                  maxLength: 1000
+                number:
+                  description: 'Freely selectable number for the customer'
+                  type: [string, 'null']
+                  maxLength: 50
+                service_assignments:
+                  description: 'Restrict to services assigned to this customer. Can only be set by administrators or workers with elevated access `manage_customers_and_projects`'
+                  oneOf: [{ type: array, items: { type: integer, minimum: 1 }, x-requires_permission: manage_services }, { type: integer, minimum: 1 }, { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }]
+                  x-requires_permission: manage_services
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/CustomerV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiCustomersV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - Customer
+      operationId: deleteCustomerByIdV3
+      parameters:
+        -
+          name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: force
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiCustomersV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/entriesTexts:
+    get:
+      tags:
+        - EntryText
+      operationId: getEntriesTextsV3
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              billable:
+                $ref: '#/components/schemas/Billable'
+              customers_id:
+                type: integer
+                minimum: 1
+              day:
+                type: string
+                format: date
+                example: '2023-02-28'
+              projects_id:
+                oneOf:
+                  - { type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }
+                  - { type: integer, minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }
+              services_id:
+                oneOf:
+                  - { type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }
+                  - { type: integer, minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }
+              time_since:
+                type: string
+                format: date
+                example: '2023-02-28'
+              time_until:
+                type: string
+                format: date
+                example: '2023-02-28'
+              users_id:
+                oneOf:
+                  - { type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }
+                  - { type: integer, minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }
+            type: object
+        -
+          name: items
+          in: query
+          description: 'Number of items to return.'
+          required: false
+          schema:
+            type: integer
+            maximum: 800
+            minimum: 1
+        -
+          name: mode
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/EntryTextMode'
+        -
+          name: term
+          in: query
+          description: 'Text to search for.'
+          required: false
+          schema:
+            type: string
+            maxLength: 1000
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/entriesText_v3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/holidaysCarry:
+    get:
+      tags:
+        - HolidayCarryover
+      operationId: getHolidaysCarryV3
+      parameters:
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: year
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 2037
+            minimum: 2000
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/HolidaysCarryV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - HolidayCarryover
+      operationId: createHolidaysCarryV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - year
+                - users_id
+                - count
+              properties:
+                year:
+                  description: 'Year for which the vacation carryover applies.'
+                  type: integer
+                  format: YYYY
+                  maximum: 2037
+                  minimum: 2000
+                  example: 2023
+                users_id:
+                  type: integer
+                  minimum: 1
+                count:
+                  description: 'Only full and half values allowed.'
+                  type: number
+                  format: float
+                  maximum: 9999
+                  minimum: -9999
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/HolidaysCarryV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiHolidaysCarryV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/holidaysCarry/{id}':
+    get:
+      tags:
+        - HolidayCarryover
+      operationId: getHolidaysCarryByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/HolidaysCarryV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - HolidayCarryover
+      operationId: updateHolidaysCarryByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                year:
+                  description: 'Year for which the vacation carryover applies.'
+                  type: integer
+                  format: YYYY
+                  maximum: 2037
+                  minimum: 2000
+                  example: 2023
+                count:
+                  description: 'Only full and half values allowed.'
+                  type: number
+                  format: float
+                  maximum: 9999
+                  minimum: -9999
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/HolidaysCarryV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiHolidaysCarryV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - HolidayCarryover
+      operationId: deleteHolidaysCarryByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiHolidaysCarryV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/overtimeCarry:
+    get:
+      tags:
+        - OvertimeCarry
+      operationId: getOvertimeCarryV3
+      parameters:
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        -
+          name: year
+          in: query
+          required: false
+          schema:
+            type: integer
+            maximum: 2037
+            minimum: 2000
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/OvertimeCarryV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - OvertimeCarry
+      operationId: createOvertimeCarryV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - year
+                - users_id
+                - hours
+              properties:
+                year:
+                  type: integer
+                  maximum: 2037
+                  minimum: 2000
+                users_id:
+                  type: integer
+                  minimum: 1
+                hours:
+                  type: number
+                  format: float
+                  maximum: 999
+                  minimum: -999
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/OvertimeCarryV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiOvertimeCarryV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/overtimeCarry/{id}':
+    get:
+      tags:
+        - OvertimeCarry
+      operationId: getOvertimeCarryByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/OvertimeCarryV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - OvertimeCarry
+      operationId: updateOvertimeCarryByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                year:
+                  type: integer
+                  maximum: 2037
+                  minimum: 2000
+                hours:
+                  type: number
+                  format: float
+                  maximum: 999
+                  minimum: -999
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/OvertimeCarryV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiOvertimeCarryV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - OvertimeCarry
+      operationId: deleteOvertimeCarryByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiOvertimeCarryV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/overtimeReductions:
+    get:
+      tags:
+        - OvertimeReduction
+      operationId: getOvertimeReductionsV3
+      parameters:
+        -
+          name: users_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              -
+                type: array
+                items:
+                  type: integer
+                  minimum: 1
+                maxItems: 500
+              -
+                type: integer
+                minimum: 1
+              -
+                type: string
+                format: csv-string
+                x-csv-element-schema:
+                  type: integer
+                  minimum: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/OvertimeReductionV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - OvertimeReduction
+      operationId: createOvertimeReductionV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - users_id
+                - date
+                - hours
+              properties:
+                users_id:
+                  type: integer
+                  minimum: 1
+                date:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                hours:
+                  type: number
+                  format: float
+                  maximum: 999
+                  minimum: -999
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/OvertimeReductionV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiOvertimeReductionsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/overtimeReductions/{id}':
+    get:
+      tags:
+        - OvertimeReduction
+      operationId: getOvertimeReductionByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/OvertimeReductionV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - OvertimeReduction
+      operationId: updateOvertimeReductionByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                date:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                hours:
+                  type: number
+                  format: float
+                  maximum: 999
+                  minimum: -999
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/OvertimeReductionV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiOvertimeReductionsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - OvertimeReduction
+      operationId: deleteOvertimeReductionByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiOvertimeReductionsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/projects/{id}/setBilled':
+    put:
+      tags:
+        - Project
+      operationId: updateProjectsSetBilledByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                billed:
+                  type: boolean
+                billed_money:
+                  type: [number, 'null']
+                  format: float
+                  maximum: 99999999
+                  minimum: 0
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ProjectV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiProjectsSetBilledV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/projects/reports:
+    get:
+      tags:
+        - ProjectReport
+      operationId: getProjectsReportsV3
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              budget_source:
+                oneOf:
+                  - { type: array, items: { $ref: '#/components/schemas/BudgetSource' } }
+                  - { $ref: '#/components/schemas/BudgetSource' }
+                  - { type: string, format: csv-string, x-csv-element-schema: { $ref: '#/components/schemas/BudgetSource' } }
+              fulltext:
+                type: string
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 250
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ApiProjectsReportsV3_SortForIndex'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/ProjectReportsV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/subprojects:
+    get:
+      tags:
+        - Subproject
+      operationId: getSubprojectsV3
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              completed:
+                type: boolean
+              fulltext:
+                type: string
+              projects_id:
+                type: integer
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 5000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortIdNameActive'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/SubprojectV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - Subproject
+      operationId: createSubprojectV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - projects_id
+                - name
+              properties:
+                projects_id:
+                  type: integer
+                name:
+                  type: string
+                  maxLength: 100
+                active:
+                  type: boolean
+                billable_default:
+                  type: boolean
+                budget:
+                  properties: { amount: { type: [number, 'null'], format: float, maximum: 99999999.99, minimum: 0 }, hard: { type: boolean }, monetary: { type: boolean }, notification_thresholds: { type: array, items: { $ref: '#/components/schemas/Thresholds' }, x-requires_module: budget_notifications } }
+                  type: [object, 'null']
+                number:
+                  type: [string, 'null']
+                  maxLength: 50
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+                start_date:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                deadline:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                automatic_completion:
+                  type: boolean
+                service_assignments:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  x-requires_permission: manage_services
+                bill_service_id:
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/SubprojectV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiSubprojectsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/subprojects/{id}':
+    get:
+      tags:
+        - Subproject
+      operationId: getSubprojectByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/SubprojectV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - Subproject
+      operationId: updateSubprojectByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                active:
+                  type: boolean
+                billable_default:
+                  type: boolean
+                budget:
+                  properties: { amount: { type: [number, 'null'], format: float, maximum: 99999999.99, minimum: 0 }, hard: { type: boolean }, monetary: { type: boolean }, notification_thresholds: { type: array, items: { $ref: '#/components/schemas/Thresholds' }, x-requires_module: budget_notifications } }
+                  type: [object, 'null']
+                number:
+                  type: [string, 'null']
+                  maxLength: 50
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+                start_date:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                deadline:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                automatic_completion:
+                  type: boolean
+                service_assignments:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  x-requires_permission: manage_services
+                bill_service_id:
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/SubprojectV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiSubprojectsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - Subproject
+      operationId: deleteSubprojectByIdV3
+      parameters:
+        -
+          name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: force
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiSubprojectsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/subprojects/{id}/complete':
+    put:
+      tags:
+        - Subproject
+      operationId: completeSubprojectByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - completed
+              properties:
+                completed:
+                  type: boolean
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/SubprojectV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiSubprojectsCompleteV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/teams:
+    get:
+      tags:
+        - Team
+      operationId: getTeamsV3
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              fulltext:
+                type: string
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 1000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/UserScope'
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortIdName'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/TeamV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - Team
+      operationId: createTeamV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                leader:
+                  description: 'The user ID of the team leader'
+                  type: [integer, 'null']
+                user_ids:
+                  oneOf: [{ type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }, { type: integer, minimum: 1 }, { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }]
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/TeamV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiTeamsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/teams/{id}':
+    get:
+      tags:
+        - Team
+      operationId: getTeamByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/TeamV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - Team
+      operationId: updateTeamByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                leader:
+                  description: 'The user ID of the team leader'
+                  type: [integer, 'null']
+                user_ids:
+                  oneOf: [{ type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }, { type: integer, minimum: 1 }, { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }]
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/TeamV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiTeamsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - Team
+      operationId: deleteTeamByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiTeamsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/users:
+    get:
+      tags:
+        - User
+      operationId: getUsersV3
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              fulltext:
+                type: string
+              teams_id:
+                oneOf:
+                  - { type: array, items: { type: [integer, 'null'], minimum: 0 }, maxItems: 500 }
+                  - { type: [integer, 'null'], minimum: 0 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: [integer, 'null'], minimum: 0 } }
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 1000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/UserScope'
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            oneOf:
+              -
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiUsersV3_SortForIndex'
+              -
+                $ref: '#/components/schemas/ApiUsersV3_SortForIndex'
+              -
+                type: string
+                format: csv-string
+                x-csv-element-schema:
+                  $ref: '#/components/schemas/ApiUsersV3_SortForIndex'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/UserV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - User
+      operationId: createUserV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - email
+                - name
+                - role
+              properties:
+                email:
+                  type: string
+                  format: email
+                  maxLength: 90
+                name:
+                  type: string
+                  maxLength: 100
+                role:
+                  $ref: '#/components/schemas/Role'
+                active:
+                  type: boolean
+                boss:
+                  type: [integer, 'null']
+                  minimum: 1
+                number:
+                  type: [string, 'null']
+                  maxLength: 50
+                language:
+                  $ref: '#/components/schemas/Language'
+                teams_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                timeformat_12h:
+                  description: 'Use 12h time format?'
+                  type: boolean
+                timezone:
+                  $ref: '#/components/schemas/ConvertibleTimezone'
+                wage_type:
+                  $ref: '#/components/schemas/WageType'
+                weekstart_monday:
+                  description: 'Start week on Monday?'
+                  type: boolean
+                show_favorites:
+                  type: boolean
+                mail_to_user:
+                  description: 'Sent mail to the new co-worker? (default: false)'
+                  type: boolean
+                start_date:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                budget_notifications:
+                  type: boolean
+                  x-requires_module: budget_notifications
+                edit_lock:
+                  description: 'The date after the co-worker is not allowed to edit his entries anymore. Can only be set by administrators or workers with elevated access `manage_users_access`.'
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                edit_lock_dyn:
+                  oneOf: [{ $ref: '#/components/schemas/EditLockDay', description: 'Dynamic edit lock for this co-worker. Can only be set by administrators or workers with elevated access `manage_users_access`.' }, { type: 'null' }]
+                  description: 'Dynamic edit lock for this co-worker. Can only be set by administrators or workers with elevated access `manage_users_access`.'
+                edit_lock_sync:
+                  description: 'Can future changes to the company-wide edit lock overwrite the edit lock for this co-worker? Can only be set by administrators or workers with elevated access `manage_users_access`.'
+                  type: boolean
+                work_time_edit_lock_days:
+                  oneOf: [{ $ref: '#/components/schemas/WorkTimeEditLockDay', description: 'Relative work time editing lock in days for the co-worker. Can only be set by administrators or workers with elevated access `manage_users_access`.' }, { type: 'null' }]
+                  description: 'Relative work time editing lock in days for the co-worker. Can only be set by administrators or workers with elevated access `manage_users_access`.'
+                default_holidays_count:
+                  description: "Uses the company's default holiday count"
+                  type: boolean
+                default_target_hours:
+                  description: "Uses the company's default target hours"
+                  type: boolean
+                work_time_regulations_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                default_work_time_regulation:
+                  description: "Uses the company's default work time regulation"
+                  type: boolean
+                exempt_from_flextime:
+                  description: 'Is exempt from flextime violation evaluation'
+                  type: boolean
+                absence_managers_id:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 500
+                  minItems: 0
+                access_groups_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 30
+                  minItems: 0
+                bill_service_id:
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/UserV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiUsersV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/users/{id}':
+    get:
+      tags:
+        - User
+      operationId: getUserByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/UserScope'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/UserV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - User
+      operationId: updateUserByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                email:
+                  type: string
+                  format: email
+                  maxLength: 90
+                name:
+                  type: string
+                  maxLength: 100
+                role:
+                  $ref: '#/components/schemas/Role'
+                active:
+                  type: boolean
+                boss:
+                  type: [integer, 'null']
+                  minimum: 1
+                number:
+                  type: [string, 'null']
+                  maxLength: 50
+                language:
+                  $ref: '#/components/schemas/Language'
+                teams_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                timeformat_12h:
+                  description: 'Use 12h time format?'
+                  type: boolean
+                timezone:
+                  $ref: '#/components/schemas/ConvertibleTimezone'
+                  description: 'Can only be changed for the company creator during the trial phase.'
+                wage_type:
+                  $ref: '#/components/schemas/WageType'
+                weekstart_monday:
+                  description: 'Start week on Monday?'
+                  type: boolean
+                show_favorites:
+                  type: boolean
+                edit_lock:
+                  description: 'The date after the co-worker is not allowed to edit his entries anymore. Can only be managed by administrators or workers with elevated access `manage_users_access`.'
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                edit_lock_dyn:
+                  oneOf: [{ $ref: '#/components/schemas/EditLockDay', description: 'Dynamic edit lock for this co-worker. Can only be managed by administrators or workers with elevated access `manage_users_access`.' }, { type: 'null' }]
+                  description: 'Dynamic edit lock for this co-worker. Can only be managed by administrators or workers with elevated access `manage_users_access`.'
+                edit_lock_sync:
+                  description: 'Can future changes to the company-wide edit lock overwrite the edit lock for this co-worker? Can only be managed by administrators or workers with elevated access `manage_users_access`.'
+                  type: boolean
+                work_time_edit_lock_days:
+                  oneOf: [{ $ref: '#/components/schemas/WorkTimeEditLockDay', description: 'Relative work time editing lock in days for the co-worker. Can only be managed by administrators or workers with elevated access `manage_users_access`.' }, { type: 'null' }]
+                  description: 'Relative work time editing lock in days for the co-worker. Can only be managed by administrators or workers with elevated access `manage_users_access`.'
+                mail_to_user:
+                  type: boolean
+                start_date:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                budget_notifications:
+                  type: boolean
+                  x-requires_module: budget_notifications
+                default_holidays_count:
+                  description: "Uses the company's default holiday count"
+                  type: boolean
+                default_target_hours:
+                  description: "Uses the company's default target hours"
+                  type: boolean
+                work_time_regulations_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                default_work_time_regulation:
+                  description: "Uses the company's default work time regulation"
+                  type: boolean
+                exempt_from_flextime:
+                  description: 'Is exempt from flextime violation evaluation'
+                  type: boolean
+                absence_managers_id:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 500
+                  minItems: 0
+                access_groups_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 30
+                  minItems: 0
+                bill_service_id:
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/UserV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiUsersV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - User
+      operationId: deleteUserByIdV3
+      parameters:
+        -
+          name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: force
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiUsersV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v3/usersNonbusinessGroups:
+    get:
+      tags:
+        - UserNonbusinessGroup
+      operationId: getUsersNonbusinessGroupsV3
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              nonbusiness_groups_id:
+                oneOf:
+                  - { type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }
+                  - { type: integer, minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }
+              users_id:
+                oneOf:
+                  - { type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }
+                  - { type: integer, minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 1000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/UsersNonbusinessGroupV3' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - UserNonbusinessGroup
+      operationId: createUsersNonbusinessGroupV3
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - users_id
+                - nonbusiness_groups_id
+                - date_since
+              properties:
+                users_id:
+                  type: integer
+                nonbusiness_groups_id:
+                  type: integer
+                date_since:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                date_until:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/UsersNonbusinessGroupV3' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiUsersNonbusinessGroupsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/usersNonbusinessGroups/{id}':
+    get:
+      tags:
+        - UserNonbusinessGroup
+      operationId: getUsersNonbusinessGroupByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/UsersNonbusinessGroupV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - UserNonbusinessGroup
+      operationId: updateUsersNonbusinessGroupByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                nonbusiness_groups_id:
+                  type: integer
+                date_since:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                date_until:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/UsersNonbusinessGroupV3' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiUsersNonbusinessGroupsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - UserNonbusinessGroup
+      operationId: deleteUsersNonbusinessGroupByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiUsersNonbusinessGroupsV3Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v3/workTimes/changeRequests/{id}/approve':
+    post:
+      tags:
+        - WorkTime
+      operationId: approveWorkTimesChangeRequestByIdV3
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                approve_violations:
+                  type: boolean
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '400':
+          description: 'An error occurred'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleErrorResponses'
+      deprecated: false
+  /v4/absences:
+    get:
+      tags:
+        - Absence
+      operationId: getAbsencesV4
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              status:
+                oneOf:
+                  - { type: array, items: { $ref: '#/components/schemas/AbsenceStatus' }, maxItems: 500 }
+                  - { $ref: '#/components/schemas/AbsenceStatus' }
+                  - { type: string, format: csv-string, x-csv-element-schema: { $ref: '#/components/schemas/AbsenceStatus' } }
+              teams_id:
+                oneOf:
+                  - { type: array, items: { type: [integer, 'null'], minimum: 1 }, maxItems: 500 }
+                  - { type: [integer, 'null'], minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: [integer, 'null'], minimum: 1 } }
+              type:
+                oneOf:
+                  - { type: array, items: { $ref: '#/components/schemas/AbsenceType' }, maxItems: 500 }
+                  - { $ref: '#/components/schemas/AbsenceType' }
+                  - { type: string, format: csv-string, x-csv-element-schema: { $ref: '#/components/schemas/AbsenceType' } }
+              users_active:
+                type: boolean
+              users_id:
+                oneOf:
+                  - { type: array, items: { type: integer, minimum: 1 }, maxItems: 500 }
+                  - { type: integer, minimum: 1 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, minimum: 1 } }
+              year:
+                oneOf:
+                  - { type: array, items: { type: integer, maximum: 2037, minimum: 2000 }, maxItems: 500 }
+                  - { type: integer, maximum: 2037, minimum: 2000 }
+                  - { type: string, format: csv-string, x-csv-element-schema: { type: integer, maximum: 2037, minimum: 2000 } }
+            type: object
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/AbsenceScope'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/AbsenceV4' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - Absence
+      operationId: createAbsenceV4
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - date_since
+                - type
+              properties:
+                date_since:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                date_until:
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                type:
+                  $ref: '#/components/schemas/AbsenceType'
+                half_day:
+                  type: boolean
+                count_hours:
+                  type: [number, 'null']
+                  format: float
+                  maximum: 1000
+                  minimum: 0.01
+                users_id:
+                  type: integer
+                  minimum: 1
+                allow_override:
+                  description: 'IDs of absences that may be shortened or deleted to avoid conflicts'
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 500
+                status:
+                  $ref: '#/components/schemas/AbsenceStatus'
+                sick_note:
+                  type: boolean
+                note:
+                  type: [string, 'null']
+                  maxLength: 512
+                public_note:
+                  type: [string, 'null']
+                  maxLength: 512
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/AbsenceV4' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAbsencesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v4/absences/{id}':
+    get:
+      tags:
+        - Absence
+      operationId: getAbsenceByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/AbsenceV4' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - Absence
+      operationId: updateAbsenceByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                date_since:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                date_until:
+                  type: string
+                  format: date
+                  example: '2023-02-28'
+                type:
+                  $ref: '#/components/schemas/AbsenceType'
+                half_day:
+                  type: boolean
+                count_hours:
+                  type: [number, 'null']
+                  format: float
+                  maximum: 1000
+                  minimum: 0.01
+                allow_override:
+                  description: 'IDs of absences that may be shortened or deleted to avoid conflicts'
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 500
+                status:
+                  $ref: '#/components/schemas/AbsenceStatus'
+                sick_note:
+                  type: boolean
+                note:
+                  type: [string, 'null']
+                  maxLength: 512
+                public_note:
+                  type: [string, 'null']
+                  maxLength: 512
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/AbsenceV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAbsencesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - Absence
+      operationId: deleteAbsenceByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiAbsencesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v4/lumpSumServices:
+    get:
+      tags:
+        - LumpSumService
+      operationId: getLumpSumServicesV4
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              fulltext:
+                type: string
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 5000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortIdNameActive'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/LumpSumServiceV4' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - LumpSumService
+      operationId: createLumpSumServiceV4
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - price
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                price:
+                  description: 'Price per unit'
+                  type: number
+                  format: float
+                  maximum: 99999999.99
+                  minimum: -99999999.99
+                unit:
+                  type: [string, 'null']
+                  maxLength: 6
+                active:
+                  type: boolean
+                number:
+                  description: 'Lump sum service number'
+                  type: [string, 'null']
+                  maxLength: 50
+                note:
+                  description: 'Only visible for administrators or workers with elevated access `manage_services`'
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/LumpSumServiceV4' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiLumpSumServicesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v4/lumpSumServices/{id}':
+    get:
+      tags:
+        - LumpSumService
+      operationId: getLumpSumServiceByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/LumpSumServiceV4' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - LumpSumService
+      operationId: updateLumpSumServiceByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                price:
+                  description: 'Price per unit'
+                  type: number
+                  format: float
+                  maximum: 99999999.99
+                  minimum: -99999999.99
+                unit:
+                  type: [string, 'null']
+                  maxLength: 6
+                active:
+                  type: boolean
+                number:
+                  description: 'Lump sum service number'
+                  type: [string, 'null']
+                  maxLength: 50
+                note:
+                  description: 'Only visible for administrators or workers with elevated access `manage_services`'
+                  type: [string, 'null']
+                  maxLength: 1000
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/LumpSumServiceV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiLumpSumServicesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - LumpSumService
+      operationId: deleteLumpSumServiceByIdV4
+      parameters:
+        -
+          name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: force
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiLumpSumServicesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v4/projects:
+    get:
+      tags:
+        - Project
+      operationId: getProjectsV4
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              completed:
+                type: boolean
+              customers_id:
+                type: integer
+              fulltext:
+                type: string
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 5000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/CustomerProjectScope'
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortIdNameActive'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/ProjectV4' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - Project
+      operationId: createProjectV4
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - customers_id
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                customers_id:
+                  type: integer
+                active:
+                  type: boolean
+                number:
+                  description: 'Freely selectable number for the project'
+                  type: [string, 'null']
+                  maxLength: 50
+                billable_default:
+                  type: boolean
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+                deadline:
+                  description: 'Date when the project will be completed automatically'
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                start_date:
+                  description: 'Date when the project becomes available for time tracking'
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                automatic_completion:
+                  type: boolean
+                budget:
+                  description: 'Use `null` for projects without budget. If a budget object is provided, `budget.amount` must be included.'
+                  properties: { amount: { description: 'For own project budget and interval budget, value must be greater than `0`. For `budget.from_subprojects=true`, value must be empty (`null` or `0`).', type: [number, 'null'], format: float, maximum: 99999999, minimum: 0 }, from_subprojects: { type: boolean }, hard: { type: boolean }, interval: { oneOf: [{ $ref: '#/components/schemas/BudgetInterval' }, { type: 'null' }], x: { requires_module: retainer } }, monetary: { type: boolean }, notification_thresholds: { type: array, items: { $ref: '#/components/schemas/Thresholds' }, x-requires_module: budget_notifications } }
+                  type: [object, 'null']
+                service_assignments:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  x-requires_permission: manage_services
+                bill_service_id:
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ProjectV4' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiProjectsV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v4/projects/{id}':
+    get:
+      tags:
+        - Project
+      operationId: getProjectByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ProjectV4' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - Project
+      operationId: updateProjectByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                customers_id:
+                  type: integer
+                active:
+                  type: boolean
+                number:
+                  description: 'Freely selectable number for the project'
+                  type: [string, 'null']
+                  maxLength: 50
+                billable_default:
+                  type: boolean
+                note:
+                  type: [string, 'null']
+                  maxLength: 1000
+                deadline:
+                  description: 'Date when the project will be completed automatically'
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                start_date:
+                  description: 'Date when the project becomes available for time tracking'
+                  type: [string, 'null']
+                  format: date
+                  example: '2023-02-28'
+                automatic_completion:
+                  type: boolean
+                budget:
+                  description: 'Use `null` for projects without budget. If a budget object is provided, `budget.amount` must be included.'
+                  properties: { amount: { description: 'For own project budget and interval budget, value must be greater than `0`. For `budget.from_subprojects=true`, value must be empty (`null` or `0`).', type: [number, 'null'], format: float, maximum: 99999999, minimum: 0 }, from_subprojects: { type: boolean }, hard: { type: boolean }, interval: { oneOf: [{ $ref: '#/components/schemas/BudgetInterval' }, { type: 'null' }], x: { requires_module: retainer } }, monetary: { type: boolean }, notification_thresholds: { type: array, items: { $ref: '#/components/schemas/Thresholds' }, x-requires_module: budget_notifications } }
+                  type: [object, 'null']
+                service_assignments:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  x-requires_permission: manage_services
+                bill_service_id:
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ProjectV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiProjectsV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - Project
+      operationId: deleteProjectByIdV4
+      parameters:
+        -
+          name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: force
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiProjectsV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v4/projects/{id}/complete':
+    put:
+      tags:
+        - Project
+      operationId: completeProjectByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - completed
+              properties:
+                completed:
+                  type: boolean
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ProjectV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiProjectsCompleteV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v4/projects/reports:
+    get:
+      tags:
+        - ProjectReport
+      operationId: getProjectsReportsV4
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              budget_source:
+                oneOf:
+                  - { type: array, items: { $ref: '#/components/schemas/BudgetSource' } }
+                  - { $ref: '#/components/schemas/BudgetSource' }
+                  - { type: string, format: csv-string, x-csv-element-schema: { $ref: '#/components/schemas/BudgetSource' } }
+              fulltext:
+                type: string
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 250
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ApiProjectsReportsV4_SortForIndex'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/ProjectsReportReportItemV4' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v4/rates:
+    get:
+      tags:
+        - Rate
+      operationId: getRatesV4
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { type: array, items: { $ref: '#/components/schemas/RateV4' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - Rate
+      operationId: createRateV4
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - hourly_rate
+              properties:
+                parent_rate_id:
+                  type: [integer, 'null']
+                  minimum: 1
+                customer_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                project_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                service_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                user_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                hourly_rate:
+                  type: number
+                  format: float
+                  maximum: 99999999.99
+                  minimum: 0
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/RateV4' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiRatesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v4/rates/default:
+    put:
+      tags:
+        - Rate
+      operationId: updateRatesDefaultV4
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - hourly_rate
+              properties:
+                hourly_rate:
+                  type: number
+                  format: float
+                  maximum: 99999999.99
+                  minimum: 0
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/RatesDefaultV4' }
+                type: object
+      deprecated: false
+  '/v4/rates/{id}':
+    get:
+      tags:
+        - Rate
+      operationId: getRateByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/RateV4' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - Rate
+      operationId: updateRateByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                customer_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                project_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                service_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                user_ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 50
+                hourly_rate:
+                  type: number
+                  format: float
+                  maximum: 99999999.99
+                  minimum: 0
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/RateV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiRatesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - Rate
+      operationId: deleteRateByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiRatesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v4/rates/{id}/sort':
+    put:
+      tags:
+        - Rate
+      operationId: updateRatesSortByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Pass 0 for root level'
+          required: true
+          schema:
+            type: integer
+            minimum: 0
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - ids
+              properties:
+                ids:
+                  type: array
+                  items: { type: integer, minimum: 1 }
+                  maxItems: 500
+                  minItems: 1
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/RatesSortV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiRatesSortV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v4/services:
+    get:
+      tags:
+        - Service
+      operationId: getServicesV4
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          style: deepObject
+          explode: true
+          schema:
+            properties:
+              active:
+                type: boolean
+              fulltext:
+                type: string
+            type: object
+        -
+          name: items_per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            maximum: 5000
+            minimum: 1
+            example: 100
+        -
+          name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            example: 1
+        -
+          name: scope
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/ServiceScope'
+        -
+          name: sort
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SortIdNameActive'
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - paging
+                  - data
+                properties:
+                  paging: { required: [items_per_page, current_page, count_pages, count_items], properties: { items_per_page: { type: integer, format: int64, example: 1000 }, current_page: { type: integer, format: int64, example: 1 }, count_pages: { type: integer, format: int64, example: 1 }, count_items: { type: integer, format: int64, example: 4 } }, type: object }
+                  data: { type: array, items: { $ref: '#/components/schemas/ServiceV4' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    post:
+      tags:
+        - Service
+      operationId: createServiceV4
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                active:
+                  type: boolean
+                number:
+                  description: 'Freely selectable number for the service.'
+                  type: [string, 'null']
+                  maxLength: 50
+                note:
+                  description: 'Only visible for administrators or workers with elevated access `manage_services`.'
+                  type: [string, 'null']
+                  maxLength: 1000
+                bill_service_id:
+                  description: 'Can only be set by administrators or workers with elevated access `manage_services` and if a billing application with services support is linked up.'
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ServiceV4' }
+                type: object
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '404':
+          description: 'Not Found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiServicesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  '/v4/services/{id}':
+    get:
+      tags:
+        - Service
+      operationId: getServiceByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ServiceV4' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    put:
+      tags:
+        - Service
+      operationId: updateServiceByIdV4
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 100
+                active:
+                  type: boolean
+                number:
+                  description: 'Freely selectable number for the service.'
+                  type: [string, 'null']
+                  maxLength: 50
+                note:
+                  description: 'Only visible for administrators or workers with elevated access `manage_services`.'
+                  type: [string, 'null']
+                  maxLength: 1000
+                bill_service_id:
+                  description: 'Can only be set by administrators or workers with elevated access `manage_services` and if a billing application with services support is linked up.'
+                  type: [string, 'null']
+                  maxLength: 50
+              type: object
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/ServiceV4' }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiServicesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+    delete:
+      tags:
+        - Service
+      operationId: deleteServiceByIdV4
+      parameters:
+        -
+          name: dry_run
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: force
+          in: query
+          required: false
+          schema:
+            type: boolean
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - success
+                properties:
+                  success: { title: Success, type: boolean, example: true }
+                type: object
+        '422':
+          description: 'Unprocessable Entity'
+          content:
+            application/json:
+              schema:
+                required:
+                  - errors
+                properties:
+                  errors: { type: array, items: { $ref: '#/components/schemas/ApiServicesV4Errors' } }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+  /v4/users/me:
+    get:
+      tags:
+        - User
+      operationId: getUsersMeV4
+      responses:
+        '200':
+          description: 'Successful operation'
+          content:
+            application/json:
+              schema:
+                required:
+                  - data
+                properties:
+                  data: { $ref: '#/components/schemas/UserV3' }
+                type: object
+        '400':
+          description: 'Bad request'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralErrors'
+      deprecated: false
+components:
+  schemas:
+    AbsenceCollision:
+      required:
+        - colliding_absences
+      properties:
+        colliding_absences:
+          type: array
+          items:
+            type: integer
+      type: object
+    AbsenceCollisionError:
+      title: 'Absence collision error'
+      properties:
+        type:
+          type: string
+          enum:
+            - AbsenceCollision
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/AbsenceCollision'
+      type: object
+      x-error-category: BadRequest
+    AbsenceDayAbsenceV4:
+      required:
+        - id
+        - users_id
+        - date_since
+        - date_until
+        - status
+        - public_note
+        - count_days
+      properties:
+        id:
+          type: integer
+        users_id:
+          type: integer
+        date_since:
+          type: string
+          format: date
+        date_until:
+          type: string
+          format: date
+        type:
+          $ref: '#/components/schemas/DayAbsenceType'
+          description: 'Only with access rights for absence administration or in case of own absences'
+        status:
+          $ref: '#/components/schemas/AbsenceStatus'
+        note:
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - string
+            - 'null'
+        public_note:
+          type:
+            - string
+            - 'null'
+        sick_note:
+          description: 'Only with access rights for absence administration or in case of own absences. Only for types 4 (SickSelf) and 5 (SickChild). Null in case of other absences.'
+          type:
+            - boolean
+            - 'null'
+        count_days:
+          title: 'Amount of absence days'
+          description: 'Null in case of overtime reduction.'
+          type: number
+          format: float
+        count_hours:
+          title: 'Amount of hours of overtime reduction'
+          description: 'Only with access rights for absence administration or in case of own absences. Null in case of other absences.'
+          type: 'null'
+        date_enquired:
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - string
+            - 'null'
+          format: date
+        date_approved:
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - string
+            - 'null'
+          format: date
+        approved_by:
+          title: 'ID of the user who has approved, declined or cancelled the request'
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - integer
+            - 'null'
+      type: object
+    AbsenceHasToBeDeclinedError:
+      title: 'Absence has to be declined error'
+      properties:
+        type:
+          type: string
+          enum:
+            - AbsenceHasToBeDeclined
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The absence has to be declined first.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    AbsenceHourAbsenceV4:
+      required:
+        - id
+        - users_id
+        - date_since
+        - date_until
+        - status
+        - public_note
+        - count_days
+      properties:
+        id:
+          type: integer
+        users_id:
+          type: integer
+        date_since:
+          type: string
+          format: date
+        date_until:
+          type: string
+          format: date
+        type:
+          $ref: '#/components/schemas/HourAbsenceType'
+          description: 'Only with access rights for absence administration or in case of own absences'
+        status:
+          $ref: '#/components/schemas/AbsenceStatus'
+        note:
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - string
+            - 'null'
+        public_note:
+          type:
+            - string
+            - 'null'
+        sick_note:
+          description: 'Only with access rights for absence administration or in case of own absences. Only for types 4 (SickSelf) and 5 (SickChild). Null in case of other absences.'
+          type:
+            - boolean
+            - 'null'
+        count_days:
+          title: 'Amount of absence days'
+          description: 'Null in case of overtime reduction.'
+          type: number
+          format: float
+        count_hours:
+          title: 'Amount of hours of overtime reduction'
+          description: 'Only with access rights for absence administration or in case of own absences. Null in case of other absences.'
+          type: number
+          format: float
+        date_enquired:
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - string
+            - 'null'
+          format: date
+        date_approved:
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - string
+            - 'null'
+          format: date
+        approved_by:
+          title: 'ID of the user who has approved, declined or cancelled the request'
+          description: 'Only with access rights for absence administration or in case of own absences'
+          type:
+            - integer
+            - 'null'
+      type: object
+    AbsenceScope:
+      title: 'Absence scope'
+      description: "Possible values:\n- `manageableAbsences`: ManageableAbsences\n- `viewableAbsences`: ViewableAbsences"
+      type: string
+      enum:
+        - manageableAbsences
+        - viewableAbsences
+      x-enumNames:
+        - ManageableAbsences
+        - ViewableAbsences
+    AbsenceStatus:
+      title: 'Absence status'
+      description: "Possible values:\n- `0`: Enquired\n- `1`: Approved\n- `2`: Declined\n- `3`: ApprovalCancelled\n- `4`: Cancelled"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+      x-enumNames:
+        - Enquired
+        - Approved
+        - Declined
+        - ApprovalCancelled
+        - Cancelled
+    AbsenceType:
+      title: 'Absence type'
+      description: "Possible values:\n- `1`: Holiday from the quota\n- `2`: Special leaves\n- `3`: Reduction of overtime\n- `4`: Sick day\n- `5`: Sick day of a child\n- `6`: School / further education\n- `7`: Maternity protection\n- `8`: Home office (planned hours get applied)\n- `9`: Work out of office (planned hours get applied)\n- `10`: Special leaves (unpaid)\n- `11`: Sick day (unpaid)\n- `12`: Sick day of a child (unpaid)\n- `13`: Quarantine (work not possible)\n- `14`: Military / alternative service\n- `15`: Sick day (sickness benefit)"
+      type: integer
+      enum:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+      x-enumNames:
+        - RegularHoliday
+        - SpecialLeave
+        - OverTimeReduction
+        - SickSelf
+        - SickChild
+        - School
+        - MaternityProtection
+        - HomeOffice
+        - OutOfOffice
+        - SpecialLeaveUnpaid
+        - SickSelfUnpaid
+        - SickChildUnpaid
+        - Quarantine
+        - MilitaryService
+        - SickSelfWithCertificate
+    AbsenceV4:
+      oneOf:
+        -
+          $ref: '#/components/schemas/AbsenceHourAbsenceV4'
+        -
+          $ref: '#/components/schemas/AbsenceDayAbsenceV4'
+    AccessGroupV2:
+      required:
+        - id
+        - name
+        - company_default
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          maxLength: 100
+          example: Marketing
+        users_ids:
+          description: 'IDs of the access group members'
+          type: array
+          items:
+            type: integer
+            format: int64
+          example:
+            - 1
+        has_elevated_access:
+          description: 'The access group contains elevated access. `null` in case of disabled project times module.'
+          type:
+            - boolean
+            - 'null'
+        has_master_data_access:
+          description: 'The access group contains master data access (customers, projects, services). `null` in case of disabled project times module.'
+          type:
+            - boolean
+            - 'null'
+        company_default:
+          description: 'The access group is one of the company default access groups.'
+          type: boolean
+      type: object
+    AccessType:
+      title: 'Access type'
+      description: "Possible values:\n- `add`: AddData\n- `report`: SeeReports\n- `edit`: EditReports"
+      type: string
+      enum:
+        - add
+        - report
+        - edit
+      x-enumNames:
+        - AddData
+        - SeeReports
+        - EditReports
+    ApiAccessGroupsServicesGeneralV2_AccessTypeForPut:
+      title: 'Access type for put'
+      description: "Possible values:\n- `add`: AddData"
+      type: string
+      enum:
+        - add
+      x-enumNames:
+        - AddData
+    ApiAccessGroupsServicesV2_AccessTypeForPut:
+      title: 'Access type for put'
+      description: "Possible values:\n- `add`: AddData"
+      type: string
+      enum:
+        - add
+      x-enumNames:
+        - AddData
+    AccessValue:
+      title: 'Access value'
+      description: "Possible values:\n- `0`: NoAccess\n- `1`: FullAccess\n- `2`: CustomAccess"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+      x-enumNames:
+        - NoAccess
+        - FullAccess
+        - CustomAccess
+    ApiAccessGroupsProjectsV2_AccessValueForPut:
+      title: 'Access value for put'
+      description: "Possible values:\n- `0`: NoAccess\n- `1`: FullAccess"
+      type: integer
+      enum:
+        - 0
+        - 1
+      x-enumNames:
+        - NoAccess
+        - FullAccess
+    ApiAccessGroupsServicesV2_AccessValueForPut:
+      title: 'Access value for put'
+      description: "Possible values:\n- `0`: NoAccess\n- `1`: FullAccess"
+      type: integer
+      enum:
+        - 0
+        - 1
+      x-enumNames:
+        - NoAccess
+        - FullAccess
+    ActivationForInactiveProjectIsForbiddenError:
+      title: 'Activation for inactive project is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ActivationForInactiveProjectIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Subprojects from inactive projects cannot be reactivated.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    AggregatesUsersMeV2:
+      required:
+        - user
+        - company
+        - worktime_regulation
+      properties:
+        user:
+          $ref: '#/components/schemas/UserV1'
+        company:
+          $ref: '#/components/schemas/CompanyV1'
+        worktime_regulation:
+          oneOf:
+            -
+              $ref: '#/components/schemas/WorkTimeRegulationV3'
+            -
+              type: 'null'
+      type: object
+    AllowedValues:
+      required:
+        - allowed_values
+      properties:
+        allowed_values:
+          type: array
+          items: {  }
+      type: object
+    AllSubprojectsMustBeCompletedError:
+      title: 'All subprojects must be completed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - AllSubprojectsMustBeCompleted
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'All subprojects must be completed before the parent project can be completed.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ApiAbsencesV4Errors:
+      title: 'Api absences v4 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/AbsenceHasToBeDeclinedError'
+            -
+              $ref: '#/components/schemas/AbsenceCollisionError'
+            -
+              $ref: '#/components/schemas/EmptyError'
+            -
+              $ref: '#/components/schemas/FieldsShouldBeEmptyError'
+            -
+              $ref: '#/components/schemas/HalfDayAbsenceTooLongError'
+            -
+              $ref: '#/components/schemas/StatusIsForbiddenError'
+            -
+              $ref: '#/components/schemas/UntilMustBeInSameYearError'
+            -
+              $ref: '#/components/schemas/UntilBeforeSinceIsForbiddenError'
+            -
+              $ref: '#/components/schemas/CannotManageAbsencesOfUserError'
+      type: object
+    ApiAccessGroupsCustomersGeneralV2Errors:
+      title: 'Api access groups customers general v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ForbiddenChangeToCustomAccessError'
+            -
+              $ref: '#/components/schemas/BlockingAccessDependenciesError'
+      type: object
+    ApiAccessGroupsServicesGeneralV2Errors:
+      title: 'Api access groups services general v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ForbiddenChangeToCustomAccessError'
+      type: object
+    ApiAccessGroupsV2Errors:
+      title: 'Api access groups v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/MissingManageUsersAccessError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/ResourcesNotFoundError'
+            -
+              $ref: '#/components/schemas/UsersExceedAccessGroupLimitError'
+      type: object
+    ApiCustomersV3Errors:
+      title: 'Api customers v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/UnexpectedValueError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/HasToBeInactiveError'
+            -
+              $ref: '#/components/schemas/ArchiveCompanyDefaultIsNotAllowedError'
+            -
+              $ref: '#/components/schemas/CannotModifyDemoDataError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+            -
+              $ref: '#/components/schemas/ServiceDoesNotExistError'
+      type: object
+    ApiErrors:
+      properties:
+        type:
+          description: 'Unique identifier of the error'
+          type: string
+          example: General
+        message:
+          description: 'Textual error description'
+          type: string
+          example: 'The requested resource could not be found.'
+        details:
+          description: 'Additional error details if necessary'
+          type:
+            - object
+            - 'null'
+          example: null
+        path:
+          type:
+            - string
+            - 'null'
+      type: object
+    ApiHolidaysCarryV3Errors:
+      title: 'Api holidays carry v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/DuplicateEntryForUserAndYearError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+      type: object
+    ApiHolidaysQuotaV2Errors:
+      title: 'Api holidays quota v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/FieldsShouldBeEmptyError'
+            -
+              $ref: '#/components/schemas/IsDefaultHolidaysCountError'
+            -
+              $ref: '#/components/schemas/DuplicateEntryForUserAndYearError'
+            -
+              $ref: '#/components/schemas/OneOpenEndedQuotaError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/EndBeforeStartError'
+      type: object
+    ApiIndividualUserAccessCustomersGeneralV2Errors:
+      title: 'Api individual user access customers general v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ForbiddenChangeToCustomAccessError'
+            -
+              $ref: '#/components/schemas/BlockingAccessDependenciesError'
+      type: object
+    ApiIndividualUserAccessServicesGeneralV2Errors:
+      title: 'Api individual user access services general v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ForbiddenChangeToCustomAccessError'
+      type: object
+    ApiLumpSumServicesV4Errors:
+      title: 'Api lump sum services v4 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/HasToBeInactiveError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+      type: object
+    ApiNonbusinessDaysV2Errors:
+      title: 'Api nonbusiness days v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/InvalidDateError'
+            -
+              $ref: '#/components/schemas/InvalidCombinationError'
+      type: object
+    ApiNonbusinessGroupsV2Errors:
+      title: 'Api nonbusiness groups v2 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/DeleteCompanyDefaultIsNotAllowedError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+      type: object
+    ApiOvertimeCarryV3Errors:
+      title: 'Api overtime carry v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/DuplicateEntryForUserAndYearError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+      type: object
+    ApiOvertimeReductionsV3Errors:
+      title: 'Api overtime reductions v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+      type: object
+    ApiProjectsCompleteV4Errors:
+      title: 'Api projects complete v4 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/BilledMoneyCanOnlyBeSetWithHardBudgetError'
+            -
+              $ref: '#/components/schemas/BilledCanOnlyBeSetWithHourBudgetError'
+            -
+              $ref: '#/components/schemas/UnexpectedValueError'
+            -
+              $ref: '#/components/schemas/FieldsShouldBeEmptyError'
+            -
+              $ref: '#/components/schemas/BudgetTotalBelowSubprojectBudgetSumError'
+            -
+              $ref: '#/components/schemas/EmptyError'
+            -
+              $ref: '#/components/schemas/BudgetIsRequiredForRetainerProjectError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetSourceBecauseOfSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetSourceToIntervalBecauseOfEntriesError'
+            -
+              $ref: '#/components/schemas/CannotRemoveBudgetBecauseOfSubprojectBudgetsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetCommitmentBecauseOfCompletedSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetTypeBecauseOfSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotModifyDemoDataError'
+            -
+              $ref: '#/components/schemas/CompletionIsForbiddenBySubprojectCompletionError'
+            -
+              $ref: '#/components/schemas/AllSubprojectsMustBeCompletedError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/IllegalChangeForCompletedProjectError'
+            -
+              $ref: '#/components/schemas/CompletionIsForbiddenBySubprojectBudgetError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionNoBillableEntriesError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionAnyRunningEntriesError'
+            -
+              $ref: '#/components/schemas/IntervalBudgetRequiresRetainerPlanError'
+            -
+              $ref: '#/components/schemas/IntervalChangeIsForbiddenForIntervalProjectsWithSubprojectsError'
+            -
+              $ref: '#/components/schemas/HasToBeInactiveError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionTooManyLumpSumsError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+            -
+              $ref: '#/components/schemas/ProjectDeadlineIsNotBeforeProjectStartError'
+            -
+              $ref: '#/components/schemas/ProjectPeriodMustContainAllEntryStartsError'
+            -
+              $ref: '#/components/schemas/ProjectPeriodCollidesWithSubprojectPeriodsError'
+      type: object
+    ApiProjectsSetBilledV3Errors:
+      title: 'Api projects set billed v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/BilledMoneyCanOnlyBeSetWithHardBudgetError'
+            -
+              $ref: '#/components/schemas/BilledCanOnlyBeSetWithHourBudgetError'
+            -
+              $ref: '#/components/schemas/UnexpectedValueError'
+            -
+              $ref: '#/components/schemas/FieldsShouldBeEmptyError'
+            -
+              $ref: '#/components/schemas/BudgetTotalBelowSubprojectBudgetSumError'
+            -
+              $ref: '#/components/schemas/EmptyError'
+            -
+              $ref: '#/components/schemas/BudgetIsRequiredForRetainerProjectError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetSourceBecauseOfSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetSourceToIntervalBecauseOfEntriesError'
+            -
+              $ref: '#/components/schemas/CannotRemoveBudgetBecauseOfSubprojectBudgetsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetCommitmentBecauseOfCompletedSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetTypeBecauseOfSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotModifyDemoDataError'
+            -
+              $ref: '#/components/schemas/CompletionIsForbiddenBySubprojectCompletionError'
+            -
+              $ref: '#/components/schemas/AllSubprojectsMustBeCompletedError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/IllegalChangeForCompletedProjectError'
+            -
+              $ref: '#/components/schemas/CompletionIsForbiddenBySubprojectBudgetError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionNoBillableEntriesError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionAnyRunningEntriesError'
+            -
+              $ref: '#/components/schemas/IntervalBudgetRequiresRetainerPlanError'
+            -
+              $ref: '#/components/schemas/IntervalChangeIsForbiddenForIntervalProjectsWithSubprojectsError'
+            -
+              $ref: '#/components/schemas/HasToBeInactiveError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionTooManyLumpSumsError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+            -
+              $ref: '#/components/schemas/ProjectDeadlineIsNotBeforeProjectStartError'
+            -
+              $ref: '#/components/schemas/ProjectPeriodMustContainAllEntryStartsError'
+            -
+              $ref: '#/components/schemas/ProjectPeriodCollidesWithSubprojectPeriodsError'
+      type: object
+    ApiProjectsV4Errors:
+      title: 'Api projects v4 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/BilledMoneyCanOnlyBeSetWithHardBudgetError'
+            -
+              $ref: '#/components/schemas/BilledCanOnlyBeSetWithHourBudgetError'
+            -
+              $ref: '#/components/schemas/UnexpectedValueError'
+            -
+              $ref: '#/components/schemas/FieldsShouldBeEmptyError'
+            -
+              $ref: '#/components/schemas/BudgetTotalBelowSubprojectBudgetSumError'
+            -
+              $ref: '#/components/schemas/EmptyError'
+            -
+              $ref: '#/components/schemas/BudgetIsRequiredForRetainerProjectError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetSourceBecauseOfSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetSourceToIntervalBecauseOfEntriesError'
+            -
+              $ref: '#/components/schemas/CannotRemoveBudgetBecauseOfSubprojectBudgetsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetCommitmentBecauseOfCompletedSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotChangeBudgetTypeBecauseOfSubprojectsError'
+            -
+              $ref: '#/components/schemas/CannotModifyDemoDataError'
+            -
+              $ref: '#/components/schemas/CompletionIsForbiddenBySubprojectCompletionError'
+            -
+              $ref: '#/components/schemas/AllSubprojectsMustBeCompletedError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/IllegalChangeForCompletedProjectError'
+            -
+              $ref: '#/components/schemas/CompletionIsForbiddenBySubprojectBudgetError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionNoBillableEntriesError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionAnyRunningEntriesError'
+            -
+              $ref: '#/components/schemas/IntervalBudgetRequiresRetainerPlanError'
+            -
+              $ref: '#/components/schemas/IntervalChangeIsForbiddenForIntervalProjectsWithSubprojectsError'
+            -
+              $ref: '#/components/schemas/HasToBeInactiveError'
+            -
+              $ref: '#/components/schemas/ProjectCompletionTooManyLumpSumsError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+            -
+              $ref: '#/components/schemas/ProjectDeadlineIsNotBeforeProjectStartError'
+            -
+              $ref: '#/components/schemas/ProjectPeriodMustContainAllEntryStartsError'
+            -
+              $ref: '#/components/schemas/ProjectPeriodCollidesWithSubprojectPeriodsError'
+            -
+              $ref: '#/components/schemas/ServiceDoesNotExistError'
+      type: object
+    ApiRatesSortV4Errors:
+      title: 'Api rates sort v4 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/ForbiddenValueError'
+      type: object
+    ApiRatesV4Errors:
+      title: 'Api rates v4 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/AtLeastOneCriteriaRequiredError'
+            -
+              $ref: '#/components/schemas/ResourcesNotFoundError'
+            -
+              $ref: '#/components/schemas/EitherCustomersOrProjectsError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/ParentOverwriteIsForbiddenError'
+            -
+              $ref: '#/components/schemas/RateAlreadyExistsError'
+      type: object
+    ApiServicesV4Errors:
+      title: 'Api services v4 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/UnexpectedValueError'
+            -
+              $ref: '#/components/schemas/HasToBeInactiveError'
+            -
+              $ref: '#/components/schemas/ArchiveCompanyDefaultIsNotAllowedError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+      type: object
+    ApiSubprojectsCompleteV3Errors:
+      title: 'Api subprojects complete v3 errors'
+      required:
+        - error
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/ApiSubprojectsV3Errors'
+        -
+          properties:
+            error:
+              title: Errors
+              type: object
+              anyOf:
+                -
+                  $ref: '#/components/schemas/ActivationForInactiveProjectIsForbiddenError'
+                -
+                  $ref: '#/components/schemas/ArchivingNonRetainerSubprojectIsForbiddenError'
+                -
+                  $ref: '#/components/schemas/CreationForInactiveProjectIsForbiddenError'
+                -
+                  $ref: '#/components/schemas/DisableSubprojectAsWorkerIsForbiddenError'
+                -
+                  $ref: '#/components/schemas/EditInactiveSubprojectAsWorkerIsForbiddenError'
+                -
+                  $ref: '#/components/schemas/SubprojectsCanNotBeSetToBilledError'
+                -
+                  $ref: '#/components/schemas/UnexpectedValueError'
+                -
+                  $ref: '#/components/schemas/SubprojectBudgetCommitmentNotEditableForBudgetSourceError'
+                -
+                  $ref: '#/components/schemas/NotBetweenError'
+                -
+                  $ref: '#/components/schemas/SubprojectBudgetTypeNotEditableForBudgetSourceError'
+                -
+                  $ref: '#/components/schemas/RequiresBudgetError'
+                -
+                  $ref: '#/components/schemas/SubprojectBudgetModificationIsProhibitedBecauseItIsCompletedError'
+                -
+                  $ref: '#/components/schemas/SubprojectCompletionNoBillableEntriesError'
+                -
+                  $ref: '#/components/schemas/SubprojectCompletionAnyRunningEntriesError'
+                -
+                  $ref: '#/components/schemas/IntervalSubprojectMustHaveBudgetError'
+                -
+                  $ref: '#/components/schemas/SubprojectIsCompletedError'
+                -
+                  $ref: '#/components/schemas/SubprojectCreationWithBudgetIsProhibitedError'
+                -
+                  $ref: '#/components/schemas/SubprojectCompletionTooManyLumpSumsError'
+                -
+                  $ref: '#/components/schemas/ResourceConflictFoundError'
+                -
+                  $ref: '#/components/schemas/RelationsPreventDeletionError'
+                -
+                  $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+                -
+                  $ref: '#/components/schemas/BudgetTotalError'
+                -
+                  $ref: '#/components/schemas/ResourceNotFoundError'
+                -
+                  $ref: '#/components/schemas/ProjectIsCompletedError'
+                -
+                  $ref: '#/components/schemas/SubprojectCompletionWithHardBudgetIsProhibitedForCompletedProjectsError'
+                -
+                  $ref: '#/components/schemas/BudgetTotalExceedsAbsoluteMaximumError'
+                -
+                  $ref: '#/components/schemas/ShouldNotHaveBudgetError'
+                -
+                  $ref: '#/components/schemas/SubprojectDeadlineIsNotBeforeSubprojectStartError'
+                -
+                  $ref: '#/components/schemas/SubprojectPeriodMustContainAllEntryStartsError'
+                -
+                  $ref: '#/components/schemas/SubprojectPeriodIsNotWithinProjectsPeriodError'
+          type: object
+    ApiSubprojectsV3Errors:
+      title: 'Api subprojects v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ActivationForInactiveProjectIsForbiddenError'
+            -
+              $ref: '#/components/schemas/ArchivingNonRetainerSubprojectIsForbiddenError'
+            -
+              $ref: '#/components/schemas/CreationForInactiveProjectIsForbiddenError'
+            -
+              $ref: '#/components/schemas/DisableSubprojectAsWorkerIsForbiddenError'
+            -
+              $ref: '#/components/schemas/EditInactiveSubprojectAsWorkerIsForbiddenError'
+            -
+              $ref: '#/components/schemas/SubprojectsCanNotBeSetToBilledError'
+            -
+              $ref: '#/components/schemas/UnexpectedValueError'
+            -
+              $ref: '#/components/schemas/SubprojectBudgetCommitmentNotEditableForBudgetSourceError'
+            -
+              $ref: '#/components/schemas/NotBetweenError'
+            -
+              $ref: '#/components/schemas/SubprojectBudgetTypeNotEditableForBudgetSourceError'
+            -
+              $ref: '#/components/schemas/RequiresBudgetError'
+            -
+              $ref: '#/components/schemas/SubprojectBudgetModificationIsProhibitedBecauseItIsCompletedError'
+            -
+              $ref: '#/components/schemas/SubprojectCompletionNoBillableEntriesError'
+            -
+              $ref: '#/components/schemas/SubprojectCompletionAnyRunningEntriesError'
+            -
+              $ref: '#/components/schemas/IntervalSubprojectMustHaveBudgetError'
+            -
+              $ref: '#/components/schemas/SubprojectIsCompletedError'
+            -
+              $ref: '#/components/schemas/SubprojectCreationWithBudgetIsProhibitedError'
+            -
+              $ref: '#/components/schemas/SubprojectCompletionTooManyLumpSumsError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+            -
+              $ref: '#/components/schemas/BudgetTotalError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/ProjectIsCompletedError'
+            -
+              $ref: '#/components/schemas/SubprojectCompletionWithHardBudgetIsProhibitedForCompletedProjectsError'
+            -
+              $ref: '#/components/schemas/BudgetTotalExceedsAbsoluteMaximumError'
+            -
+              $ref: '#/components/schemas/ShouldNotHaveBudgetError'
+            -
+              $ref: '#/components/schemas/SubprojectDeadlineIsNotBeforeSubprojectStartError'
+            -
+              $ref: '#/components/schemas/SubprojectPeriodMustContainAllEntryStartsError'
+            -
+              $ref: '#/components/schemas/SubprojectPeriodIsNotWithinProjectsPeriodError'
+            -
+              $ref: '#/components/schemas/ServiceDoesNotExistError'
+      type: object
+    ApiTeamsV3Errors:
+      title: 'Api teams v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/HasToBeActiveError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/ForbiddenError'
+            -
+              $ref: '#/components/schemas/UserHasAnotherTeamError'
+            -
+              $ref: '#/components/schemas/ResourcesNotFoundError'
+      type: object
+    ApiUsersNonbusinessGroupsV3Errors:
+      title: 'Api users nonbusiness groups v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/UsersNonbusinessGroupsCollisionError'
+            -
+              $ref: '#/components/schemas/EndBeforeStartError'
+      type: object
+    ApiUsersV3Errors:
+      title: 'Api users v3 errors'
+      required:
+        - error
+      properties:
+        error:
+          title: Errors
+          type: object
+          anyOf:
+            -
+              $ref: '#/components/schemas/ResourcesInactiveError'
+            -
+              $ref: '#/components/schemas/ResourcesNotFoundError'
+            -
+              $ref: '#/components/schemas/MissingManageUsersAccessForAssigningAccessGroupError'
+            -
+              $ref: '#/components/schemas/MissingManageUsersAccessForRemovingAccessGroupError'
+            -
+              $ref: '#/components/schemas/UnexpectedValueError'
+            -
+              $ref: '#/components/schemas/ResourceNotFoundError'
+            -
+              $ref: '#/components/schemas/InvalidCombinationError'
+            -
+              $ref: '#/components/schemas/EmailNotAvailableError'
+            -
+              $ref: '#/components/schemas/ExitDateRequiresActiveUserError'
+            -
+              $ref: '#/components/schemas/ResourceConflictFoundError'
+            -
+              $ref: '#/components/schemas/HasToBeInactiveError'
+            -
+              $ref: '#/components/schemas/MaxUsersOfPlanTypeReachedError'
+            -
+              $ref: '#/components/schemas/MaxUsersReachedError'
+            -
+              $ref: '#/components/schemas/RelationsPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventDeletionError'
+            -
+              $ref: '#/components/schemas/RunningEntriesPreventArchivingError'
+            -
+              $ref: '#/components/schemas/SsoPreventsDeactivationError'
+            -
+              $ref: '#/components/schemas/ForbiddenError'
+            -
+              $ref: '#/components/schemas/BossCannotBeArchivedError'
+            -
+              $ref: '#/components/schemas/UserCannotDeleteThemselvesError'
+            -
+              $ref: '#/components/schemas/OnlyOwnerCanDeleteOwnerError'
+            -
+              $ref: '#/components/schemas/ForbiddenValueError'
+            -
+              $ref: '#/components/schemas/MailCannotBeChangedError'
+      type: object
+    ArchiveCompanyDefaultIsNotAllowedError:
+      title: 'Archive company default is not allowed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ArchiveCompanyDefaultIsNotAllowed
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'It is not allowed to archive an item which is company default.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ArchivingNonRetainerSubprojectIsForbiddenError:
+      title: 'Archiving non retainer subproject is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ArchivingNonRetainerSubprojectIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Subprojects can only be archived for retainer projects. To remove this subproject, please delete it instead.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    AtLeastOneCriteriaRequiredError:
+      title: 'At least one criteria required error'
+      properties:
+        type:
+          type: string
+          enum:
+            - AtLeastOneCriteriaRequired
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    Billable:
+      title: Billable
+      description: "Possible values:\n- `0`: NotBillable\n- `1`: Billable\n- `2`: Billed\n- `12`: BillableOrBilled"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 12
+      x-enumNames:
+        - NotBillable
+        - Billable
+        - Billed
+        - BillableOrBilled
+    BillableDistinct:
+      title: 'Billable distinct'
+      description: "Possible values:\n- `0`: NotBillable\n- `1`: Billable\n- `2`: Billed"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+      x-enumNames:
+        - NotBillable
+        - Billable
+        - Billed
+    BillableWithoutBilled:
+      title: 'Billable without billed'
+      description: "Possible values:\n- `0`: NotBillable\n- `1`: Billable"
+      type: integer
+      enum:
+        - 0
+        - 1
+      x-enumNames:
+        - NotBillable
+        - Billable
+    BilledCanOnlyBeSetWithHourBudgetError:
+      title: 'Billed can only be set with hour budget error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BilledCanOnlyBeSetWithHourBudget
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Field can only be set for projects with hours as budget. Otherwise it is determined automatically based on the billed amount.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    BilledMoneyCanOnlyBeSetWithHardBudgetError:
+      title: 'Billed money can only be set with hard budget error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BilledMoneyCanOnlyBeSetWithHardBudget
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The project does not have a hard budget so that the billed amount can't be set. You have to set the single entries to billed."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    BlockingAccessDependenciesError:
+      title: 'Blocking access dependencies error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BlockingAccessDependencies
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Blocking dependencies need to be removed beforehand.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/BlockingAccessDependencies'
+      type: object
+      x-error-category: Forbidden
+    BossCannotBeArchivedError:
+      title: 'Boss cannot be archived error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BossCannotBeArchived
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Users who are bosses or team leaders cannot be archived.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    BudgetInterval:
+      title: 'Budget interval'
+      description: "Possible values:\n- `0`: Weekly\n- `1`: Monthly\n- `2`: Quarterly\n- `3`: Yearly"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+      x-enumNames:
+        - Weekly
+        - Monthly
+        - Quarterly
+        - Yearly
+    BudgetIsRequiredForRetainerProjectError:
+      title: 'Budget is required for retainer project error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BudgetIsRequiredForRetainerProject
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Budget is required for retainer projects.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    BudgetOption:
+      title: 'Budget option'
+      description: "Possible values:\n- `rep_filter_budget_strict`: Strict\n- `rep_filter_budget_strict_completed`: StrictCompleted\n- `rep_filter_budget_strict_incomplete`: StrictIncomplete\n- `rep_filter_budget_soft`: Soft\n- `rep_filter_budget_soft_completed`: SoftCompleted\n- `rep_filter_budget_soft_incomplete`: SoftIncomplete\n- `rep_filter_budget_without`: Without\n- `rep_filter_budget_without_strict`: WithoutStrict"
+      type: string
+      enum:
+        - rep_filter_budget_strict
+        - rep_filter_budget_strict_completed
+        - rep_filter_budget_strict_incomplete
+        - rep_filter_budget_soft
+        - rep_filter_budget_soft_completed
+        - rep_filter_budget_soft_incomplete
+        - rep_filter_budget_without
+        - rep_filter_budget_without_strict
+      x-enumNames:
+        - Strict
+        - StrictCompleted
+        - StrictIncomplete
+        - Soft
+        - SoftCompleted
+        - SoftIncomplete
+        - Without
+        - WithoutStrict
+    BudgetSource:
+      title: 'Budget source'
+      description: "Possible values:\n- `0`: NoBudget\n- `1`: EnterBudget\n- `2`: GetBudgetThroughSubprojects\n- `3`: Interval"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+      x-enumNames:
+        - NoBudget
+        - EnterBudget
+        - GetBudgetThroughSubprojects
+        - Interval
+    BudgetTotalBelowSubprojectBudgetSumError:
+      title: 'Budget total below subproject budget sum error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BudgetTotalBelowSubprojectBudgetSum
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The project budget may not fall below the total budget of all subprojects.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/NotBetween'
+      type: object
+      x-error-category: BadRequest
+    BudgetTotalError:
+      title: 'Budget total error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BudgetTotal
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The total budget of all subprojects may not exceed the project budget.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/BudgetTotalErrorDetails'
+      type: object
+      x-error-category: BadRequest
+    BudgetTotalExceedsAbsoluteMaximumError:
+      title: 'Budget total exceeds absolute maximum error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BudgetTotalExceedsAbsoluteMaximum
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The total budget of all subprojects may not exceed the threshold of 99999999.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/NotBetween'
+      type: object
+      x-error-category: BadRequest
+    CannotChangeBudgetCommitmentBecauseOfCompletedSubprojectsError:
+      title: 'Cannot change budget commitment because of completed subprojects error'
+      properties:
+        type:
+          type: string
+          enum:
+            - CannotChangeBudgetCommitmentBecauseOfCompletedSubprojects
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot change the budget commitment as long as there are completed subprojects.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    CannotChangeBudgetSourceBecauseOfSubprojectsError:
+      title: 'Cannot change budget source because of subprojects error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BudgetSourceIsNotChangedFromOrToIntervalWhenSubprojectsExist
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot change the budget source of interval projects as long as there are subprojects.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    CannotChangeBudgetSourceToIntervalBecauseOfEntriesError:
+      title: 'Cannot change budget source to interval because of entries error'
+      properties:
+        type:
+          type: string
+          enum:
+            - BudgetSourceIsNotChangedToIntervalWhenEntriesExist
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot change the budget source to interval as long as there are entries.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    CannotChangeBudgetTypeBecauseOfSubprojectsError:
+      title: 'Cannot change budget type because of subprojects error'
+      properties:
+        type:
+          type: string
+          enum:
+            - CannotChangeBudgetTypeBecauseOfSubprojects
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot change the budget type (hard / soft and money / time) as long as there are subprojects.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    CannotManageAbsencesOfUserError:
+      title: 'Cannot manage absences of user error'
+      properties:
+        type:
+          description: 'Fehler, wenn Rechte fehlen, um die Abwesenheiten eines Users zu verwalten'
+          type: string
+          enum:
+            - CannotManageAbsencesOfUser
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    CannotModifyDemoDataError:
+      title: 'Cannot modify demo data error'
+      properties:
+        type:
+          type: string
+          enum:
+            - CannotModifyDemoData
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You must not edit demo data.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    CannotRemoveBudgetBecauseOfSubprojectBudgetsError:
+      title: 'Cannot remove budget because of subproject budgets error'
+      properties:
+        type:
+          type: string
+          enum:
+            - CannotRemoveBudgetBecauseOfSubprojectBudgets
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot remove the budget as long as there are subprojects with budgets.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ChangeRequestIntervalType:
+      title: 'Change request interval type'
+      description: "Possible values:\n- `1`: Added\n- `2`: Removed"
+      type: integer
+      enum:
+        - 1
+        - 2
+      x-enumNames:
+        - Added
+        - Removed
+    ChangeRequestScope:
+      title: 'Change request scope'
+      description: "Possible values:\n- `approve`: Approve"
+      type: string
+      enum:
+        - approve
+      x-enumNames:
+        - Approve
+    ChangeRequestStatus:
+      title: 'Change request status'
+      description: "Possible values:\n- `1`: Requested\n- `2`: Declined"
+      type: integer
+      enum:
+        - 1
+        - 2
+      x-enumNames:
+        - Requested
+        - Declined
+    ClockStartStopV2:
+      required:
+        - running
+        - stopped
+        - current_time
+        - stopped_has_been_truncated
+      properties:
+        running:
+          oneOf:
+            -
+              $ref: '#/components/schemas/EntryV2'
+            -
+              type: 'null'
+          type: object
+        stopped:
+          oneOf:
+            -
+              $ref: '#/components/schemas/EntryV2'
+            -
+              type: 'null'
+          type: object
+        current_time:
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        stopped_has_been_truncated:
+          title: 'Stopped entry has been shortened in order to comply with maximum duration of 24h'
+          type: boolean
+        additional_message:
+          title: 'Error Message'
+          type: string
+      type: object
+    ClockV2:
+      required:
+        - running
+        - stopped
+        - current_time
+      properties:
+        running:
+          oneOf:
+            -
+              $ref: '#/components/schemas/EntryV2'
+            -
+              type: 'null'
+          type: object
+        stopped:
+          oneOf:
+            -
+              $ref: '#/components/schemas/EntryV2'
+            -
+              type: 'null'
+          type: object
+        current_time:
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+      type: object
+    CompanyTargetHoursDefaultNodeV1:
+      required:
+        - monday
+        - tuesday
+        - wednesday
+        - thursday
+        - friday
+        - saturday
+        - sunday
+      properties:
+        monday:
+          type: number
+          format: float
+        tuesday:
+          type: number
+          format: float
+        wednesday:
+          type: number
+          format: float
+        thursday:
+          type: number
+          format: float
+        friday:
+          type: number
+          format: float
+        saturday:
+          type: number
+          format: float
+        sunday:
+          type: number
+          format: float
+      type: object
+    CompanyV1:
+      required:
+        - id
+        - name
+        - timezone_default
+        - currency
+        - allow_entries_text_multiline
+        - allow_entries_for_customers
+        - allow_entry_overlaps
+        - force_linked_entry_times
+        - default_customers_id
+        - default_services_id
+        - module_absence
+        - module_work_time
+        - module_targethours
+        - module_target_hours
+        - module_userreports
+        - module_user_reports
+        - module_project_times
+        - module_entries_texts
+        - nonbusiness_group_default
+        - onboarding_complete
+        - worktime_regulation_default
+        - worktime_evaluate_regulations_since
+        - worktime_force_breaks
+        - holidays_count_default
+        - absence_reduces_target_hours
+        - compensate_day_default
+        - compensate_month_default
+        - target_hours_default
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        timezone_default:
+          type: string
+        currency:
+          type:
+            - string
+            - 'null'
+        allow_entries_text_multiline:
+          type: boolean
+        allow_entries_for_customers:
+          type: boolean
+        allow_entry_overlaps:
+          type: boolean
+        force_linked_entry_times:
+          type: boolean
+        default_customers_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        default_services_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        module_absence:
+          type: boolean
+        module_work_time:
+          type: boolean
+        module_targethours:
+          type: boolean
+        module_target_hours:
+          type: boolean
+        module_userreports:
+          type: boolean
+        module_user_reports:
+          type: boolean
+        module_project_times:
+          type: boolean
+        module_entries_texts:
+          type: boolean
+        nonbusiness_group_default:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        onboarding_complete:
+          type: boolean
+        worktime_regulation_default:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        worktime_evaluate_regulations_since:
+          type:
+            - string
+            - 'null'
+        worktime_force_breaks:
+          type: integer
+          format: int64
+        holidays_count_default:
+          type: number
+          format: float
+        absence_reduces_target_hours:
+          type: boolean
+        compensate_day_default:
+          type: number
+          format: float
+        compensate_month_default:
+          type: number
+          format: float
+        target_hours_default:
+          $ref: '#/components/schemas/CompanyTargetHoursDefaultNodeV1'
+      type: object
+    CompletionIsForbiddenBySubprojectBudgetError:
+      title: 'Completion is forbidden by subproject budget error'
+      properties:
+        type:
+          type: string
+          enum:
+            - CompletionIsForbiddenBySubprojectBudget
+        message:
+          type:
+            - string
+            - 'null'
+          example: "Project-completion is forbidden as the subprojects's budget sum does not match the project's budget."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    CompletionIsForbiddenBySubprojectCompletionError:
+      title: 'Completion is forbidden by subproject completion error'
+      properties:
+        type:
+          type: string
+          enum:
+            - CompletionIsForbiddenBySubprojectCompletion
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Project-completion is forbidden as subprojects are completed partly.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ConvertibleTimezone:
+      title: 'Convertible timezone'
+      description: "Possible values:\n- `Africa/Abidjan`: AfricaAbidjan\n- `Africa/Accra`: AfricaAccra\n- `Africa/Addis_Ababa`: AfricaAddisAbaba\n- `Africa/Algiers`: AfricaAlgiers\n- `Africa/Asmara`: AfricaAsmara\n- `Africa/Bamako`: AfricaBamako\n- `Africa/Bangui`: AfricaBangui\n- `Africa/Banjul`: AfricaBanjul\n- `Africa/Bissau`: AfricaBissau\n- `Africa/Blantyre`: AfricaBlantyre\n- `Africa/Brazzaville`: AfricaBrazzaville\n- `Africa/Bujumbura`: AfricaBujumbura\n- `Africa/Cairo`: AfricaCairo\n- `Africa/Casablanca`: AfricaCasablanca\n- `Africa/Ceuta`: AfricaCeuta\n- `Africa/Conakry`: AfricaConakry\n- `Africa/Dakar`: AfricaDakar\n- `Africa/Dar_es_Salaam`: AfricaDarEsSalaam\n- `Africa/Djibouti`: AfricaDjibouti\n- `Africa/Douala`: AfricaDouala\n- `Africa/El_Aaiun`: AfricaElAaiun\n- `Africa/Freetown`: AfricaFreetown\n- `Africa/Gaborone`: AfricaGaborone\n- `Africa/Harare`: AfricaHarare\n- `Africa/Johannesburg`: AfricaJohannesburg\n- `Africa/Juba`: AfricaJuba\n- `Africa/Kampala`: AfricaKampala\n- `Africa/Khartoum`: AfricaKhartoum\n- `Africa/Kigali`: AfricaKigali\n- `Africa/Kinshasa`: AfricaKinshasa\n- `Africa/Lagos`: AfricaLagos\n- `Africa/Libreville`: AfricaLibreville\n- `Africa/Lome`: AfricaLome\n- `Africa/Luanda`: AfricaLuanda\n- `Africa/Lubumbashi`: AfricaLubumbashi\n- `Africa/Lusaka`: AfricaLusaka\n- `Africa/Malabo`: AfricaMalabo\n- `Africa/Maputo`: AfricaMaputo\n- `Africa/Maseru`: AfricaMaseru\n- `Africa/Mbabane`: AfricaMbabane\n- `Africa/Mogadishu`: AfricaMogadishu\n- `Africa/Monrovia`: AfricaMonrovia\n- `Africa/Nairobi`: AfricaNairobi\n- `Africa/Ndjamena`: AfricaNdjamena\n- `Africa/Niamey`: AfricaNiamey\n- `Africa/Nouakchott`: AfricaNouakchott\n- `Africa/Ouagadougou`: AfricaOuagadougou\n- `Africa/Porto-Novo`: AfricaPortoNovo\n- `Africa/Tripoli`: AfricaTripoli\n- `Africa/Tunis`: AfricaTunis\n- `Africa/Windhoek`: AfricaWindhoek\n- `America/Adak`: AmericaAdak\n- `America/Anchorage`: AmericaAnchorage\n- `America/Anguilla`: AmericaAnguilla\n- `America/Antigua`: AmericaAntigua\n- `America/Araguaina`: AmericaAraguaina\n- `America/Argentina/Buenos_Aires`: AmericaArgentinaBuenosAires\n- `America/Argentina/Catamarca`: AmericaArgentinaCatamarca\n- `America/Argentina/Cordoba`: AmericaArgentinaCordoba\n- `America/Argentina/Jujuy`: AmericaArgentinaJujuy\n- `America/Argentina/La_Rioja`: AmericaArgentinaLaRioja\n- `America/Argentina/Mendoza`: AmericaArgentinaMendoza\n- `America/Argentina/Rio_Gallegos`: AmericaArgentinaRioGallegos\n- `America/Argentina/Salta`: AmericaArgentinaSalta\n- `America/Argentina/San_Juan`: AmericaArgentinaSanJuan\n- `America/Argentina/San_Luis`: AmericaArgentinaSanLuis\n- `America/Argentina/Tucuman`: AmericaArgentinaTucuman\n- `America/Argentina/Ushuaia`: AmericaArgentinaUshuaia\n- `America/Aruba`: AmericaAruba\n- `America/Asuncion`: AmericaAsuncion\n- `America/Atikokan`: AmericaAtikokan\n- `America/Bahia`: AmericaBahia\n- `America/Bahia_Banderas`: AmericaBahiaBanderas\n- `America/Barbados`: AmericaBarbados\n- `America/Belem`: AmericaBelem\n- `America/Belize`: AmericaBelize\n- `America/Blanc-Sablon`: AmericaBlancSablon\n- `America/Boa_Vista`: AmericaBoaVista\n- `America/Bogota`: AmericaBogota\n- `America/Boise`: AmericaBoise\n- `America/Cambridge_Bay`: AmericaCambridgeBay\n- `America/Campo_Grande`: AmericaCampoGrande\n- `America/Cancun`: AmericaCancun\n- `America/Caracas`: AmericaCaracas\n- `America/Cayenne`: AmericaCayenne\n- `America/Cayman`: AmericaCayman\n- `America/Chicago`: AmericaChicago\n- `America/Chihuahua`: AmericaChihuahua\n- `America/Costa_Rica`: AmericaCostaRica\n- `America/Creston`: AmericaCreston\n- `America/Cuiaba`: AmericaCuiaba\n- `America/Curacao`: AmericaCuracao\n- `America/Danmarkshavn`: AmericaDanmarkshavn\n- `America/Dawson`: AmericaDawson\n- `America/Dawson_Creek`: AmericaDawsonCreek\n- `America/Denver`: AmericaDenver\n- `America/Detroit`: AmericaDetroit\n- `America/Dominica`: AmericaDominica\n- `America/Edmonton`: AmericaEdmonton\n- `America/Eirunepe`: AmericaEirunepe\n- `America/El_Salvador`: AmericaElSalvador\n- `America/Fort_Nelson`: AmericaFortNelson\n- `America/Fortaleza`: AmericaFortaleza\n- `America/Glace_Bay`: AmericaGlaceBay\n- `America/Goose_Bay`: AmericaGooseBay\n- `America/Grand_Turk`: AmericaGrandTurk\n- `America/Grenada`: AmericaGrenada\n- `America/Guadeloupe`: AmericaGuadeloupe\n- `America/Guatemala`: AmericaGuatemala\n- `America/Guayaquil`: AmericaGuayaquil\n- `America/Guyana`: AmericaGuyana\n- `America/Halifax`: AmericaHalifax\n- `America/Havana`: AmericaHavana\n- `America/Hermosillo`: AmericaHermosillo\n- `America/Indiana/Indianapolis`: AmericaIndianaIndianapolis\n- `America/Indiana/Knox`: AmericaIndianaKnox\n- `America/Indiana/Marengo`: AmericaIndianaMarengo\n- `America/Indiana/Petersburg`: AmericaIndianaPetersburg\n- `America/Indiana/Tell_City`: AmericaIndianaTellCity\n- `America/Indiana/Vevay`: AmericaIndianaVevay\n- `America/Indiana/Vincennes`: AmericaIndianaVincennes\n- `America/Indiana/Winamac`: AmericaIndianaWinamac\n- `America/Inuvik`: AmericaInuvik\n- `America/Iqaluit`: AmericaIqaluit\n- `America/Jamaica`: AmericaJamaica\n- `America/Juneau`: AmericaJuneau\n- `America/Kentucky/Louisville`: AmericaKentuckyLouisville\n- `America/Kentucky/Monticello`: AmericaKentuckyMonticello\n- `America/Kralendijk`: AmericaKralendijk\n- `America/La_Paz`: AmericaLaPaz\n- `America/Lima`: AmericaLima\n- `America/Los_Angeles`: AmericaLosAngeles\n- `America/Lower_Princes`: AmericaLowerPrinces\n- `America/Maceio`: AmericaMaceio\n- `America/Managua`: AmericaManagua\n- `America/Manaus`: AmericaManaus\n- `America/Marigot`: AmericaMarigot\n- `America/Martinique`: AmericaMartinique\n- `America/Matamoros`: AmericaMatamoros\n- `America/Mazatlan`: AmericaMazatlan\n- `America/Menominee`: AmericaMenominee\n- `America/Merida`: AmericaMerida\n- `America/Mexico_City`: AmericaMexicoCity\n- `America/Miquelon`: AmericaMiquelon\n- `America/Moncton`: AmericaMoncton\n- `America/Monterrey`: AmericaMonterrey\n- `America/Montevideo`: AmericaMontevideo\n- `America/Montserrat`: AmericaMontserrat\n- `America/Nassau`: AmericaNassau\n- `America/New_York`: AmericaNewYork\n- `America/Nome`: AmericaNome\n- `America/Noronha`: AmericaNoronha\n- `America/North_Dakota/Beulah`: AmericaNorthDakotaBeulah\n- `America/North_Dakota/Center`: AmericaNorthDakotaCenter\n- `America/North_Dakota/New_Salem`: AmericaNorthDakotaNewSalem\n- `America/Ojinaga`: AmericaOjinaga\n- `America/Panama`: AmericaPanama\n- `America/Paramaribo`: AmericaParamaribo\n- `America/Phoenix`: AmericaPhoenix\n- `America/Port-au-Prince`: AmericaPortAuPrince\n- `America/Port_of_Spain`: AmericaPortOfSpain\n- `America/Porto_Velho`: AmericaPortoVelho\n- `America/Puerto_Rico`: AmericaPuertoRico\n- `America/Punta_Arenas`: AmericaPuntaArenas\n- `America/Rankin_Inlet`: AmericaRankinInlet\n- `America/Recife`: AmericaRecife\n- `America/Regina`: AmericaRegina\n- `America/Resolute`: AmericaResolute\n- `America/Rio_Branco`: AmericaRioBranco\n- `America/Santarem`: AmericaSantarem\n- `America/Santiago`: AmericaSantiago\n- `America/Santo_Domingo`: AmericaSantoDomingo\n- `America/Sao_Paulo`: AmericaSaoPaulo\n- `America/Scoresbysund`: AmericaScoresbysund\n- `America/Sitka`: AmericaSitka\n- `America/St_Barthelemy`: AmericaStBarthelemy\n- `America/St_Johns`: AmericaStJohns\n- `America/St_Kitts`: AmericaStKitts\n- `America/St_Lucia`: AmericaStLucia\n- `America/St_Thomas`: AmericaStThomas\n- `America/St_Vincent`: AmericaStVincent\n- `America/Swift_Current`: AmericaSwiftCurrent\n- `America/Tegucigalpa`: AmericaTegucigalpa\n- `America/Thule`: AmericaThule\n- `America/Tijuana`: AmericaTijuana\n- `America/Toronto`: AmericaToronto\n- `America/Tortola`: AmericaTortola\n- `America/Vancouver`: AmericaVancouver\n- `America/Whitehorse`: AmericaWhitehorse\n- `America/Winnipeg`: AmericaWinnipeg\n- `America/Yakutat`: AmericaYakutat\n- `Antarctica/Davis`: AntarcticaDavis\n- `Antarctica/DumontDUrville`: AntarcticaDumontDUrville\n- `Antarctica/Macquarie`: AntarcticaMacquarie\n- `Antarctica/Mawson`: AntarcticaMawson\n- `Antarctica/McMurdo`: AntarcticaMcMurdo\n- `Antarctica/Palmer`: AntarcticaPalmer\n- `Antarctica/Rothera`: AntarcticaRothera\n- `Antarctica/Syowa`: AntarcticaSyowa\n- `Arctic/Longyearbyen`: ArcticLongyearbyen\n- `Asia/Aden`: AsiaAden\n- `Asia/Almaty`: AsiaAlmaty\n- `Asia/Amman`: AsiaAmman\n- `Asia/Anadyr`: AsiaAnadyr\n- `Asia/Aqtau`: AsiaAqtau\n- `Asia/Aqtobe`: AsiaAqtobe\n- `Asia/Ashgabat`: AsiaAshgabat\n- `Asia/Atyrau`: AsiaAtyrau\n- `Asia/Baghdad`: AsiaBaghdad\n- `Asia/Bahrain`: AsiaBahrain\n- `Asia/Baku`: AsiaBaku\n- `Asia/Bangkok`: AsiaBangkok\n- `Asia/Barnaul`: AsiaBarnaul\n- `Asia/Beirut`: AsiaBeirut\n- `Asia/Bishkek`: AsiaBishkek\n- `Asia/Brunei`: AsiaBrunei\n- `Asia/Chita`: AsiaChita\n- `Asia/Colombo`: AsiaColombo\n- `Asia/Damascus`: AsiaDamascus\n- `Asia/Dhaka`: AsiaDhaka\n- `Asia/Dili`: AsiaDili\n- `Asia/Dubai`: AsiaDubai\n- `Asia/Dushanbe`: AsiaDushanbe\n- `Asia/Gaza`: AsiaGaza\n- `Asia/Hebron`: AsiaHebron\n- `Asia/Ho_Chi_Minh`: AsiaHoChiMinh\n- `Asia/Hong_Kong`: AsiaHongKong\n- `Asia/Hovd`: AsiaHovd\n- `Asia/Irkutsk`: AsiaIrkutsk\n- `Asia/Jakarta`: AsiaJakarta\n- `Asia/Jayapura`: AsiaJayapura\n- `Asia/Jerusalem`: AsiaJerusalem\n- `Asia/Kabul`: AsiaKabul\n- `Asia/Kamchatka`: AsiaKamchatka\n- `Asia/Karachi`: AsiaKarachi\n- `Asia/Kathmandu`: AsiaKathmandu\n- `Asia/Khandyga`: AsiaKhandyga\n- `Asia/Kolkata`: AsiaKolkata\n- `Asia/Krasnoyarsk`: AsiaKrasnoyarsk\n- `Asia/Kuala_Lumpur`: AsiaKualaLumpur\n- `Asia/Kuching`: AsiaKuching\n- `Asia/Kuwait`: AsiaKuwait\n- `Asia/Macau`: AsiaMacau\n- `Asia/Magadan`: AsiaMagadan\n- `Asia/Makassar`: AsiaMakassar\n- `Asia/Manila`: AsiaManila\n- `Asia/Muscat`: AsiaMuscat\n- `Asia/Nicosia`: AsiaNicosia\n- `Asia/Novokuznetsk`: AsiaNovokuznetsk\n- `Asia/Novosibirsk`: AsiaNovosibirsk\n- `Asia/Omsk`: AsiaOmsk\n- `Asia/Oral`: AsiaOral\n- `Asia/Phnom_Penh`: AsiaPhnomPenh\n- `Asia/Pontianak`: AsiaPontianak\n- `Asia/Pyongyang`: AsiaPyongyang\n- `Asia/Qatar`: AsiaQatar\n- `Asia/Qostanay`: AsiaQostanay\n- `Asia/Riyadh`: AsiaRiyadh\n- `Asia/Sakhalin`: AsiaSakhalin\n- `Asia/Samarkand`: AsiaSamarkand\n- `Asia/Seoul`: AsiaSeoul\n- `Asia/Shanghai`: AsiaShanghai\n- `Asia/Singapore`: AsiaSingapore\n- `Asia/Srednekolymsk`: AsiaSrednekolymsk\n- `Asia/Taipei`: AsiaTaipei\n- `Asia/Tashkent`: AsiaTashkent\n- `Asia/Tbilisi`: AsiaTbilisi\n- `Asia/Tehran`: AsiaTehran\n- `Asia/Thimphu`: AsiaThimphu\n- `Asia/Tokyo`: AsiaTokyo\n- `Asia/Tomsk`: AsiaTomsk\n- `Asia/Ulaanbaatar`: AsiaUlaanbaatar\n- `Asia/Urumqi`: AsiaUrumqi\n- `Asia/Ust-Nera`: AsiaUstNera\n- `Asia/Vientiane`: AsiaVientiane\n- `Asia/Vladivostok`: AsiaVladivostok\n- `Asia/Yakutsk`: AsiaYakutsk\n- `Asia/Yangon`: AsiaYangon\n- `Asia/Yekaterinburg`: AsiaYekaterinburg\n- `Asia/Yerevan`: AsiaYerevan\n- `Atlantic/Azores`: AtlanticAzores\n- `Atlantic/Bermuda`: AtlanticBermuda\n- `Atlantic/Canary`: AtlanticCanary\n- `Atlantic/Cape_Verde`: AtlanticCapeVerde\n- `Atlantic/Faroe`: AtlanticFaroe\n- `Atlantic/Madeira`: AtlanticMadeira\n- `Atlantic/Reykjavik`: AtlanticReykjavik\n- `Atlantic/South_Georgia`: AtlanticSouthGeorgia\n- `Atlantic/St_Helena`: AtlanticStHelena\n- `Atlantic/Stanley`: AtlanticStanley\n- `Australia/Adelaide`: AustraliaAdelaide\n- `Australia/Brisbane`: AustraliaBrisbane\n- `Australia/Broken_Hill`: AustraliaBrokenHill\n- `Australia/Darwin`: AustraliaDarwin\n- `Australia/Eucla`: AustraliaEucla\n- `Australia/Hobart`: AustraliaHobart\n- `Australia/Lindeman`: AustraliaLindeman\n- `Australia/Lord_Howe`: AustraliaLordHowe\n- `Australia/Melbourne`: AustraliaMelbourne\n- `Australia/Perth`: AustraliaPerth\n- `Australia/Sydney`: AustraliaSydney\n- `Europe/Amsterdam`: EuropeAmsterdam\n- `Europe/Andorra`: EuropeAndorra\n- `Europe/Astrakhan`: EuropeAstrakhan\n- `Europe/Athens`: EuropeAthens\n- `Europe/Belgrade`: EuropeBelgrade\n- `Europe/Berlin`: EuropeBerlin\n- `Europe/Bratislava`: EuropeBratislava\n- `Europe/Brussels`: EuropeBrussels\n- `Europe/Bucharest`: EuropeBucharest\n- `Europe/Budapest`: EuropeBudapest\n- `Europe/Busingen`: EuropeBusingen\n- `Europe/Chisinau`: EuropeChisinau\n- `Europe/Copenhagen`: EuropeCopenhagen\n- `Europe/Dublin`: EuropeDublin\n- `Europe/Gibraltar`: EuropeGibraltar\n- `Europe/Guernsey`: EuropeGuernsey\n- `Europe/Helsinki`: EuropeHelsinki\n- `Europe/Isle_of_Man`: EuropeIsleOfMan\n- `Europe/Istanbul`: EuropeIstanbul\n- `Europe/Jersey`: EuropeJersey\n- `Europe/Kaliningrad`: EuropeKaliningrad\n- `Europe/Kirov`: EuropeKirov\n- `Europe/Kyiv`: EuropeKyiv\n- `Europe/Lisbon`: EuropeLisbon\n- `Europe/Ljubljana`: EuropeLjubljana\n- `Europe/London`: EuropeLondon\n- `Europe/Luxembourg`: EuropeLuxembourg\n- `Europe/Madrid`: EuropeMadrid\n- `Europe/Malta`: EuropeMalta\n- `Europe/Mariehamn`: EuropeMariehamn\n- `Europe/Minsk`: EuropeMinsk\n- `Europe/Monaco`: EuropeMonaco\n- `Europe/Moscow`: EuropeMoscow\n- `Europe/Oslo`: EuropeOslo\n- `Europe/Paris`: EuropeParis\n- `Europe/Podgorica`: EuropePodgorica\n- `Europe/Prague`: EuropePrague\n- `Europe/Riga`: EuropeRiga\n- `Europe/Rome`: EuropeRome\n- `Europe/Samara`: EuropeSamara\n- `Europe/San_Marino`: EuropeSanMarino\n- `Europe/Sarajevo`: EuropeSarajevo\n- `Europe/Saratov`: EuropeSaratov\n- `Europe/Simferopol`: EuropeSimferopol\n- `Europe/Skopje`: EuropeSkopje\n- `Europe/Sofia`: EuropeSofia\n- `Europe/Stockholm`: EuropeStockholm\n- `Europe/Tallinn`: EuropeTallinn\n- `Europe/Tirane`: EuropeTirane\n- `Europe/Ulyanovsk`: EuropeUlyanovsk\n- `Europe/Vaduz`: EuropeVaduz\n- `Europe/Vatican`: EuropeVatican\n- `Europe/Vienna`: EuropeVienna\n- `Europe/Vilnius`: EuropeVilnius\n- `Europe/Volgograd`: EuropeVolgograd\n- `Europe/Warsaw`: EuropeWarsaw\n- `Europe/Zagreb`: EuropeZagreb\n- `Europe/Zurich`: EuropeZurich\n- `Indian/Antananarivo`: IndianAntananarivo\n- `Indian/Chagos`: IndianChagos\n- `Indian/Christmas`: IndianChristmas\n- `Indian/Cocos`: IndianCocos\n- `Indian/Comoro`: IndianComoro\n- `Indian/Kerguelen`: IndianKerguelen\n- `Indian/Mahe`: IndianMahe\n- `Indian/Maldives`: IndianMaldives\n- `Indian/Mauritius`: IndianMauritius\n- `Indian/Mayotte`: IndianMayotte\n- `Indian/Reunion`: IndianReunion\n- `Pacific/Apia`: PacificApia\n- `Pacific/Auckland`: PacificAuckland\n- `Pacific/Bougainville`: PacificBougainville\n- `Pacific/Chatham`: PacificChatham\n- `Pacific/Chuuk`: PacificChuuk\n- `Pacific/Easter`: PacificEaster\n- `Pacific/Efate`: PacificEfate\n- `Pacific/Fakaofo`: PacificFakaofo\n- `Pacific/Fiji`: PacificFiji\n- `Pacific/Funafuti`: PacificFunafuti\n- `Pacific/Galapagos`: PacificGalapagos\n- `Pacific/Gambier`: PacificGambier\n- `Pacific/Guadalcanal`: PacificGuadalcanal\n- `Pacific/Guam`: PacificGuam\n- `Pacific/Honolulu`: PacificHonolulu\n- `Pacific/Kiritimati`: PacificKiritimati\n- `Pacific/Kosrae`: PacificKosrae\n- `Pacific/Kwajalein`: PacificKwajalein\n- `Pacific/Majuro`: PacificMajuro\n- `Pacific/Marquesas`: PacificMarquesas\n- `Pacific/Midway`: PacificMidway\n- `Pacific/Nauru`: PacificNauru\n- `Pacific/Niue`: PacificNiue\n- `Pacific/Norfolk`: PacificNorfolk\n- `Pacific/Noumea`: PacificNoumea\n- `Pacific/Pago_Pago`: PacificPagoPago\n- `Pacific/Palau`: PacificPalau\n- `Pacific/Pitcairn`: PacificPitcairn\n- `Pacific/Pohnpei`: PacificPohnpei\n- `Pacific/Port_Moresby`: PacificPortMoresby\n- `Pacific/Rarotonga`: PacificRarotonga\n- `Pacific/Saipan`: PacificSaipan\n- `Pacific/Tahiti`: PacificTahiti\n- `Pacific/Tarawa`: PacificTarawa\n- `Pacific/Tongatapu`: PacificTongatapu\n- `Pacific/Wake`: PacificWake\n- `Pacific/Wallis`: PacificWallis\n- `UTC`: Utc"
+      type: string
+      enum:
+        - Africa/Abidjan
+        - Africa/Accra
+        - Africa/Addis_Ababa
+        - Africa/Algiers
+        - Africa/Asmara
+        - Africa/Bamako
+        - Africa/Bangui
+        - Africa/Banjul
+        - Africa/Bissau
+        - Africa/Blantyre
+        - Africa/Brazzaville
+        - Africa/Bujumbura
+        - Africa/Cairo
+        - Africa/Casablanca
+        - Africa/Ceuta
+        - Africa/Conakry
+        - Africa/Dakar
+        - Africa/Dar_es_Salaam
+        - Africa/Djibouti
+        - Africa/Douala
+        - Africa/El_Aaiun
+        - Africa/Freetown
+        - Africa/Gaborone
+        - Africa/Harare
+        - Africa/Johannesburg
+        - Africa/Juba
+        - Africa/Kampala
+        - Africa/Khartoum
+        - Africa/Kigali
+        - Africa/Kinshasa
+        - Africa/Lagos
+        - Africa/Libreville
+        - Africa/Lome
+        - Africa/Luanda
+        - Africa/Lubumbashi
+        - Africa/Lusaka
+        - Africa/Malabo
+        - Africa/Maputo
+        - Africa/Maseru
+        - Africa/Mbabane
+        - Africa/Mogadishu
+        - Africa/Monrovia
+        - Africa/Nairobi
+        - Africa/Ndjamena
+        - Africa/Niamey
+        - Africa/Nouakchott
+        - Africa/Ouagadougou
+        - Africa/Porto-Novo
+        - Africa/Tripoli
+        - Africa/Tunis
+        - Africa/Windhoek
+        - America/Adak
+        - America/Anchorage
+        - America/Anguilla
+        - America/Antigua
+        - America/Araguaina
+        - America/Argentina/Buenos_Aires
+        - America/Argentina/Catamarca
+        - America/Argentina/Cordoba
+        - America/Argentina/Jujuy
+        - America/Argentina/La_Rioja
+        - America/Argentina/Mendoza
+        - America/Argentina/Rio_Gallegos
+        - America/Argentina/Salta
+        - America/Argentina/San_Juan
+        - America/Argentina/San_Luis
+        - America/Argentina/Tucuman
+        - America/Argentina/Ushuaia
+        - America/Aruba
+        - America/Asuncion
+        - America/Atikokan
+        - America/Bahia
+        - America/Bahia_Banderas
+        - America/Barbados
+        - America/Belem
+        - America/Belize
+        - America/Blanc-Sablon
+        - America/Boa_Vista
+        - America/Bogota
+        - America/Boise
+        - America/Cambridge_Bay
+        - America/Campo_Grande
+        - America/Cancun
+        - America/Caracas
+        - America/Cayenne
+        - America/Cayman
+        - America/Chicago
+        - America/Chihuahua
+        - America/Costa_Rica
+        - America/Creston
+        - America/Cuiaba
+        - America/Curacao
+        - America/Danmarkshavn
+        - America/Dawson
+        - America/Dawson_Creek
+        - America/Denver
+        - America/Detroit
+        - America/Dominica
+        - America/Edmonton
+        - America/Eirunepe
+        - America/El_Salvador
+        - America/Fort_Nelson
+        - America/Fortaleza
+        - America/Glace_Bay
+        - America/Goose_Bay
+        - America/Grand_Turk
+        - America/Grenada
+        - America/Guadeloupe
+        - America/Guatemala
+        - America/Guayaquil
+        - America/Guyana
+        - America/Halifax
+        - America/Havana
+        - America/Hermosillo
+        - America/Indiana/Indianapolis
+        - America/Indiana/Knox
+        - America/Indiana/Marengo
+        - America/Indiana/Petersburg
+        - America/Indiana/Tell_City
+        - America/Indiana/Vevay
+        - America/Indiana/Vincennes
+        - America/Indiana/Winamac
+        - America/Inuvik
+        - America/Iqaluit
+        - America/Jamaica
+        - America/Juneau
+        - America/Kentucky/Louisville
+        - America/Kentucky/Monticello
+        - America/Kralendijk
+        - America/La_Paz
+        - America/Lima
+        - America/Los_Angeles
+        - America/Lower_Princes
+        - America/Maceio
+        - America/Managua
+        - America/Manaus
+        - America/Marigot
+        - America/Martinique
+        - America/Matamoros
+        - America/Mazatlan
+        - America/Menominee
+        - America/Merida
+        - America/Mexico_City
+        - America/Miquelon
+        - America/Moncton
+        - America/Monterrey
+        - America/Montevideo
+        - America/Montserrat
+        - America/Nassau
+        - America/New_York
+        - America/Nome
+        - America/Noronha
+        - America/North_Dakota/Beulah
+        - America/North_Dakota/Center
+        - America/North_Dakota/New_Salem
+        - America/Ojinaga
+        - America/Panama
+        - America/Paramaribo
+        - America/Phoenix
+        - America/Port-au-Prince
+        - America/Port_of_Spain
+        - America/Porto_Velho
+        - America/Puerto_Rico
+        - America/Punta_Arenas
+        - America/Rankin_Inlet
+        - America/Recife
+        - America/Regina
+        - America/Resolute
+        - America/Rio_Branco
+        - America/Santarem
+        - America/Santiago
+        - America/Santo_Domingo
+        - America/Sao_Paulo
+        - America/Scoresbysund
+        - America/Sitka
+        - America/St_Barthelemy
+        - America/St_Johns
+        - America/St_Kitts
+        - America/St_Lucia
+        - America/St_Thomas
+        - America/St_Vincent
+        - America/Swift_Current
+        - America/Tegucigalpa
+        - America/Thule
+        - America/Tijuana
+        - America/Toronto
+        - America/Tortola
+        - America/Vancouver
+        - America/Whitehorse
+        - America/Winnipeg
+        - America/Yakutat
+        - Antarctica/Davis
+        - Antarctica/DumontDUrville
+        - Antarctica/Macquarie
+        - Antarctica/Mawson
+        - Antarctica/McMurdo
+        - Antarctica/Palmer
+        - Antarctica/Rothera
+        - Antarctica/Syowa
+        - Arctic/Longyearbyen
+        - Asia/Aden
+        - Asia/Almaty
+        - Asia/Amman
+        - Asia/Anadyr
+        - Asia/Aqtau
+        - Asia/Aqtobe
+        - Asia/Ashgabat
+        - Asia/Atyrau
+        - Asia/Baghdad
+        - Asia/Bahrain
+        - Asia/Baku
+        - Asia/Bangkok
+        - Asia/Barnaul
+        - Asia/Beirut
+        - Asia/Bishkek
+        - Asia/Brunei
+        - Asia/Chita
+        - Asia/Colombo
+        - Asia/Damascus
+        - Asia/Dhaka
+        - Asia/Dili
+        - Asia/Dubai
+        - Asia/Dushanbe
+        - Asia/Gaza
+        - Asia/Hebron
+        - Asia/Ho_Chi_Minh
+        - Asia/Hong_Kong
+        - Asia/Hovd
+        - Asia/Irkutsk
+        - Asia/Jakarta
+        - Asia/Jayapura
+        - Asia/Jerusalem
+        - Asia/Kabul
+        - Asia/Kamchatka
+        - Asia/Karachi
+        - Asia/Kathmandu
+        - Asia/Khandyga
+        - Asia/Kolkata
+        - Asia/Krasnoyarsk
+        - Asia/Kuala_Lumpur
+        - Asia/Kuching
+        - Asia/Kuwait
+        - Asia/Macau
+        - Asia/Magadan
+        - Asia/Makassar
+        - Asia/Manila
+        - Asia/Muscat
+        - Asia/Nicosia
+        - Asia/Novokuznetsk
+        - Asia/Novosibirsk
+        - Asia/Omsk
+        - Asia/Oral
+        - Asia/Phnom_Penh
+        - Asia/Pontianak
+        - Asia/Pyongyang
+        - Asia/Qatar
+        - Asia/Qostanay
+        - Asia/Riyadh
+        - Asia/Sakhalin
+        - Asia/Samarkand
+        - Asia/Seoul
+        - Asia/Shanghai
+        - Asia/Singapore
+        - Asia/Srednekolymsk
+        - Asia/Taipei
+        - Asia/Tashkent
+        - Asia/Tbilisi
+        - Asia/Tehran
+        - Asia/Thimphu
+        - Asia/Tokyo
+        - Asia/Tomsk
+        - Asia/Ulaanbaatar
+        - Asia/Urumqi
+        - Asia/Ust-Nera
+        - Asia/Vientiane
+        - Asia/Vladivostok
+        - Asia/Yakutsk
+        - Asia/Yangon
+        - Asia/Yekaterinburg
+        - Asia/Yerevan
+        - Atlantic/Azores
+        - Atlantic/Bermuda
+        - Atlantic/Canary
+        - Atlantic/Cape_Verde
+        - Atlantic/Faroe
+        - Atlantic/Madeira
+        - Atlantic/Reykjavik
+        - Atlantic/South_Georgia
+        - Atlantic/St_Helena
+        - Atlantic/Stanley
+        - Australia/Adelaide
+        - Australia/Brisbane
+        - Australia/Broken_Hill
+        - Australia/Darwin
+        - Australia/Eucla
+        - Australia/Hobart
+        - Australia/Lindeman
+        - Australia/Lord_Howe
+        - Australia/Melbourne
+        - Australia/Perth
+        - Australia/Sydney
+        - Europe/Amsterdam
+        - Europe/Andorra
+        - Europe/Astrakhan
+        - Europe/Athens
+        - Europe/Belgrade
+        - Europe/Berlin
+        - Europe/Bratislava
+        - Europe/Brussels
+        - Europe/Bucharest
+        - Europe/Budapest
+        - Europe/Busingen
+        - Europe/Chisinau
+        - Europe/Copenhagen
+        - Europe/Dublin
+        - Europe/Gibraltar
+        - Europe/Guernsey
+        - Europe/Helsinki
+        - Europe/Isle_of_Man
+        - Europe/Istanbul
+        - Europe/Jersey
+        - Europe/Kaliningrad
+        - Europe/Kirov
+        - Europe/Kyiv
+        - Europe/Lisbon
+        - Europe/Ljubljana
+        - Europe/London
+        - Europe/Luxembourg
+        - Europe/Madrid
+        - Europe/Malta
+        - Europe/Mariehamn
+        - Europe/Minsk
+        - Europe/Monaco
+        - Europe/Moscow
+        - Europe/Oslo
+        - Europe/Paris
+        - Europe/Podgorica
+        - Europe/Prague
+        - Europe/Riga
+        - Europe/Rome
+        - Europe/Samara
+        - Europe/San_Marino
+        - Europe/Sarajevo
+        - Europe/Saratov
+        - Europe/Simferopol
+        - Europe/Skopje
+        - Europe/Sofia
+        - Europe/Stockholm
+        - Europe/Tallinn
+        - Europe/Tirane
+        - Europe/Ulyanovsk
+        - Europe/Vaduz
+        - Europe/Vatican
+        - Europe/Vienna
+        - Europe/Vilnius
+        - Europe/Volgograd
+        - Europe/Warsaw
+        - Europe/Zagreb
+        - Europe/Zurich
+        - Indian/Antananarivo
+        - Indian/Chagos
+        - Indian/Christmas
+        - Indian/Cocos
+        - Indian/Comoro
+        - Indian/Kerguelen
+        - Indian/Mahe
+        - Indian/Maldives
+        - Indian/Mauritius
+        - Indian/Mayotte
+        - Indian/Reunion
+        - Pacific/Apia
+        - Pacific/Auckland
+        - Pacific/Bougainville
+        - Pacific/Chatham
+        - Pacific/Chuuk
+        - Pacific/Easter
+        - Pacific/Efate
+        - Pacific/Fakaofo
+        - Pacific/Fiji
+        - Pacific/Funafuti
+        - Pacific/Galapagos
+        - Pacific/Gambier
+        - Pacific/Guadalcanal
+        - Pacific/Guam
+        - Pacific/Honolulu
+        - Pacific/Kiritimati
+        - Pacific/Kosrae
+        - Pacific/Kwajalein
+        - Pacific/Majuro
+        - Pacific/Marquesas
+        - Pacific/Midway
+        - Pacific/Nauru
+        - Pacific/Niue
+        - Pacific/Norfolk
+        - Pacific/Noumea
+        - Pacific/Pago_Pago
+        - Pacific/Palau
+        - Pacific/Pitcairn
+        - Pacific/Pohnpei
+        - Pacific/Port_Moresby
+        - Pacific/Rarotonga
+        - Pacific/Saipan
+        - Pacific/Tahiti
+        - Pacific/Tarawa
+        - Pacific/Tongatapu
+        - Pacific/Wake
+        - Pacific/Wallis
+        - UTC
+      x-enumNames:
+        - AfricaAbidjan
+        - AfricaAccra
+        - AfricaAddisAbaba
+        - AfricaAlgiers
+        - AfricaAsmara
+        - AfricaBamako
+        - AfricaBangui
+        - AfricaBanjul
+        - AfricaBissau
+        - AfricaBlantyre
+        - AfricaBrazzaville
+        - AfricaBujumbura
+        - AfricaCairo
+        - AfricaCasablanca
+        - AfricaCeuta
+        - AfricaConakry
+        - AfricaDakar
+        - AfricaDarEsSalaam
+        - AfricaDjibouti
+        - AfricaDouala
+        - AfricaElAaiun
+        - AfricaFreetown
+        - AfricaGaborone
+        - AfricaHarare
+        - AfricaJohannesburg
+        - AfricaJuba
+        - AfricaKampala
+        - AfricaKhartoum
+        - AfricaKigali
+        - AfricaKinshasa
+        - AfricaLagos
+        - AfricaLibreville
+        - AfricaLome
+        - AfricaLuanda
+        - AfricaLubumbashi
+        - AfricaLusaka
+        - AfricaMalabo
+        - AfricaMaputo
+        - AfricaMaseru
+        - AfricaMbabane
+        - AfricaMogadishu
+        - AfricaMonrovia
+        - AfricaNairobi
+        - AfricaNdjamena
+        - AfricaNiamey
+        - AfricaNouakchott
+        - AfricaOuagadougou
+        - AfricaPortoNovo
+        - AfricaTripoli
+        - AfricaTunis
+        - AfricaWindhoek
+        - AmericaAdak
+        - AmericaAnchorage
+        - AmericaAnguilla
+        - AmericaAntigua
+        - AmericaAraguaina
+        - AmericaArgentinaBuenosAires
+        - AmericaArgentinaCatamarca
+        - AmericaArgentinaCordoba
+        - AmericaArgentinaJujuy
+        - AmericaArgentinaLaRioja
+        - AmericaArgentinaMendoza
+        - AmericaArgentinaRioGallegos
+        - AmericaArgentinaSalta
+        - AmericaArgentinaSanJuan
+        - AmericaArgentinaSanLuis
+        - AmericaArgentinaTucuman
+        - AmericaArgentinaUshuaia
+        - AmericaAruba
+        - AmericaAsuncion
+        - AmericaAtikokan
+        - AmericaBahia
+        - AmericaBahiaBanderas
+        - AmericaBarbados
+        - AmericaBelem
+        - AmericaBelize
+        - AmericaBlancSablon
+        - AmericaBoaVista
+        - AmericaBogota
+        - AmericaBoise
+        - AmericaCambridgeBay
+        - AmericaCampoGrande
+        - AmericaCancun
+        - AmericaCaracas
+        - AmericaCayenne
+        - AmericaCayman
+        - AmericaChicago
+        - AmericaChihuahua
+        - AmericaCostaRica
+        - AmericaCreston
+        - AmericaCuiaba
+        - AmericaCuracao
+        - AmericaDanmarkshavn
+        - AmericaDawson
+        - AmericaDawsonCreek
+        - AmericaDenver
+        - AmericaDetroit
+        - AmericaDominica
+        - AmericaEdmonton
+        - AmericaEirunepe
+        - AmericaElSalvador
+        - AmericaFortNelson
+        - AmericaFortaleza
+        - AmericaGlaceBay
+        - AmericaGooseBay
+        - AmericaGrandTurk
+        - AmericaGrenada
+        - AmericaGuadeloupe
+        - AmericaGuatemala
+        - AmericaGuayaquil
+        - AmericaGuyana
+        - AmericaHalifax
+        - AmericaHavana
+        - AmericaHermosillo
+        - AmericaIndianaIndianapolis
+        - AmericaIndianaKnox
+        - AmericaIndianaMarengo
+        - AmericaIndianaPetersburg
+        - AmericaIndianaTellCity
+        - AmericaIndianaVevay
+        - AmericaIndianaVincennes
+        - AmericaIndianaWinamac
+        - AmericaInuvik
+        - AmericaIqaluit
+        - AmericaJamaica
+        - AmericaJuneau
+        - AmericaKentuckyLouisville
+        - AmericaKentuckyMonticello
+        - AmericaKralendijk
+        - AmericaLaPaz
+        - AmericaLima
+        - AmericaLosAngeles
+        - AmericaLowerPrinces
+        - AmericaMaceio
+        - AmericaManagua
+        - AmericaManaus
+        - AmericaMarigot
+        - AmericaMartinique
+        - AmericaMatamoros
+        - AmericaMazatlan
+        - AmericaMenominee
+        - AmericaMerida
+        - AmericaMexicoCity
+        - AmericaMiquelon
+        - AmericaMoncton
+        - AmericaMonterrey
+        - AmericaMontevideo
+        - AmericaMontserrat
+        - AmericaNassau
+        - AmericaNewYork
+        - AmericaNome
+        - AmericaNoronha
+        - AmericaNorthDakotaBeulah
+        - AmericaNorthDakotaCenter
+        - AmericaNorthDakotaNewSalem
+        - AmericaOjinaga
+        - AmericaPanama
+        - AmericaParamaribo
+        - AmericaPhoenix
+        - AmericaPortAuPrince
+        - AmericaPortOfSpain
+        - AmericaPortoVelho
+        - AmericaPuertoRico
+        - AmericaPuntaArenas
+        - AmericaRankinInlet
+        - AmericaRecife
+        - AmericaRegina
+        - AmericaResolute
+        - AmericaRioBranco
+        - AmericaSantarem
+        - AmericaSantiago
+        - AmericaSantoDomingo
+        - AmericaSaoPaulo
+        - AmericaScoresbysund
+        - AmericaSitka
+        - AmericaStBarthelemy
+        - AmericaStJohns
+        - AmericaStKitts
+        - AmericaStLucia
+        - AmericaStThomas
+        - AmericaStVincent
+        - AmericaSwiftCurrent
+        - AmericaTegucigalpa
+        - AmericaThule
+        - AmericaTijuana
+        - AmericaToronto
+        - AmericaTortola
+        - AmericaVancouver
+        - AmericaWhitehorse
+        - AmericaWinnipeg
+        - AmericaYakutat
+        - AntarcticaDavis
+        - AntarcticaDumontDUrville
+        - AntarcticaMacquarie
+        - AntarcticaMawson
+        - AntarcticaMcMurdo
+        - AntarcticaPalmer
+        - AntarcticaRothera
+        - AntarcticaSyowa
+        - ArcticLongyearbyen
+        - AsiaAden
+        - AsiaAlmaty
+        - AsiaAmman
+        - AsiaAnadyr
+        - AsiaAqtau
+        - AsiaAqtobe
+        - AsiaAshgabat
+        - AsiaAtyrau
+        - AsiaBaghdad
+        - AsiaBahrain
+        - AsiaBaku
+        - AsiaBangkok
+        - AsiaBarnaul
+        - AsiaBeirut
+        - AsiaBishkek
+        - AsiaBrunei
+        - AsiaChita
+        - AsiaColombo
+        - AsiaDamascus
+        - AsiaDhaka
+        - AsiaDili
+        - AsiaDubai
+        - AsiaDushanbe
+        - AsiaGaza
+        - AsiaHebron
+        - AsiaHoChiMinh
+        - AsiaHongKong
+        - AsiaHovd
+        - AsiaIrkutsk
+        - AsiaJakarta
+        - AsiaJayapura
+        - AsiaJerusalem
+        - AsiaKabul
+        - AsiaKamchatka
+        - AsiaKarachi
+        - AsiaKathmandu
+        - AsiaKhandyga
+        - AsiaKolkata
+        - AsiaKrasnoyarsk
+        - AsiaKualaLumpur
+        - AsiaKuching
+        - AsiaKuwait
+        - AsiaMacau
+        - AsiaMagadan
+        - AsiaMakassar
+        - AsiaManila
+        - AsiaMuscat
+        - AsiaNicosia
+        - AsiaNovokuznetsk
+        - AsiaNovosibirsk
+        - AsiaOmsk
+        - AsiaOral
+        - AsiaPhnomPenh
+        - AsiaPontianak
+        - AsiaPyongyang
+        - AsiaQatar
+        - AsiaQostanay
+        - AsiaRiyadh
+        - AsiaSakhalin
+        - AsiaSamarkand
+        - AsiaSeoul
+        - AsiaShanghai
+        - AsiaSingapore
+        - AsiaSrednekolymsk
+        - AsiaTaipei
+        - AsiaTashkent
+        - AsiaTbilisi
+        - AsiaTehran
+        - AsiaThimphu
+        - AsiaTokyo
+        - AsiaTomsk
+        - AsiaUlaanbaatar
+        - AsiaUrumqi
+        - AsiaUstNera
+        - AsiaVientiane
+        - AsiaVladivostok
+        - AsiaYakutsk
+        - AsiaYangon
+        - AsiaYekaterinburg
+        - AsiaYerevan
+        - AtlanticAzores
+        - AtlanticBermuda
+        - AtlanticCanary
+        - AtlanticCapeVerde
+        - AtlanticFaroe
+        - AtlanticMadeira
+        - AtlanticReykjavik
+        - AtlanticSouthGeorgia
+        - AtlanticStHelena
+        - AtlanticStanley
+        - AustraliaAdelaide
+        - AustraliaBrisbane
+        - AustraliaBrokenHill
+        - AustraliaDarwin
+        - AustraliaEucla
+        - AustraliaHobart
+        - AustraliaLindeman
+        - AustraliaLordHowe
+        - AustraliaMelbourne
+        - AustraliaPerth
+        - AustraliaSydney
+        - EuropeAmsterdam
+        - EuropeAndorra
+        - EuropeAstrakhan
+        - EuropeAthens
+        - EuropeBelgrade
+        - EuropeBerlin
+        - EuropeBratislava
+        - EuropeBrussels
+        - EuropeBucharest
+        - EuropeBudapest
+        - EuropeBusingen
+        - EuropeChisinau
+        - EuropeCopenhagen
+        - EuropeDublin
+        - EuropeGibraltar
+        - EuropeGuernsey
+        - EuropeHelsinki
+        - EuropeIsleOfMan
+        - EuropeIstanbul
+        - EuropeJersey
+        - EuropeKaliningrad
+        - EuropeKirov
+        - EuropeKyiv
+        - EuropeLisbon
+        - EuropeLjubljana
+        - EuropeLondon
+        - EuropeLuxembourg
+        - EuropeMadrid
+        - EuropeMalta
+        - EuropeMariehamn
+        - EuropeMinsk
+        - EuropeMonaco
+        - EuropeMoscow
+        - EuropeOslo
+        - EuropeParis
+        - EuropePodgorica
+        - EuropePrague
+        - EuropeRiga
+        - EuropeRome
+        - EuropeSamara
+        - EuropeSanMarino
+        - EuropeSarajevo
+        - EuropeSaratov
+        - EuropeSimferopol
+        - EuropeSkopje
+        - EuropeSofia
+        - EuropeStockholm
+        - EuropeTallinn
+        - EuropeTirane
+        - EuropeUlyanovsk
+        - EuropeVaduz
+        - EuropeVatican
+        - EuropeVienna
+        - EuropeVilnius
+        - EuropeVolgograd
+        - EuropeWarsaw
+        - EuropeZagreb
+        - EuropeZurich
+        - IndianAntananarivo
+        - IndianChagos
+        - IndianChristmas
+        - IndianCocos
+        - IndianComoro
+        - IndianKerguelen
+        - IndianMahe
+        - IndianMaldives
+        - IndianMauritius
+        - IndianMayotte
+        - IndianReunion
+        - PacificApia
+        - PacificAuckland
+        - PacificBougainville
+        - PacificChatham
+        - PacificChuuk
+        - PacificEaster
+        - PacificEfate
+        - PacificFakaofo
+        - PacificFiji
+        - PacificFunafuti
+        - PacificGalapagos
+        - PacificGambier
+        - PacificGuadalcanal
+        - PacificGuam
+        - PacificHonolulu
+        - PacificKiritimati
+        - PacificKosrae
+        - PacificKwajalein
+        - PacificMajuro
+        - PacificMarquesas
+        - PacificMidway
+        - PacificNauru
+        - PacificNiue
+        - PacificNorfolk
+        - PacificNoumea
+        - PacificPagoPago
+        - PacificPalau
+        - PacificPitcairn
+        - PacificPohnpei
+        - PacificPortMoresby
+        - PacificRarotonga
+        - PacificSaipan
+        - PacificTahiti
+        - PacificTarawa
+        - PacificTongatapu
+        - PacificWake
+        - PacificWallis
+        - Utc
+    CustomerCountProjectsV3:
+      title: CountProjects
+      description: 'The number of active and inactive projects for one customer'
+      required:
+        - customers_id
+        - active
+        - inactive
+      properties:
+        customers_id:
+          type: integer
+          format: int64
+          example: 10
+        active:
+          title: 'Number of active projects'
+          type: integer
+          format: int64
+          example: 504
+        inactive:
+          title: 'Number of inactive projects'
+          type: integer
+          format: int64
+          example: 27
+      type: object
+    CreationForInactiveProjectIsForbiddenError:
+      title: 'Creation for inactive project is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - CreationForInactiveProjectIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Subprojects cannot be created for archived projects.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    custom_access_v2:
+      description: 'Access only to selected customers'
+      type: object
+      additionalProperties:
+        description: 'Key value pairs in the format {customer id} => true or {customer id} => {} for selected projects'
+        oneOf:
+          -
+            description: 'Access to selected customers'
+            type: boolean
+            enum:
+              - true
+          -
+            description: 'Access to selected projects'
+            required:
+              - projects
+            properties:
+              projects:
+                type: object
+                additionalProperties:
+                  description: 'Key value pairs in the format {project id} => true'
+                  type: boolean
+                  enum: [true]
+            type: object
+    CustomerV3:
+      title: Customer
+      required:
+        - id
+        - name
+        - number
+        - color
+        - active
+        - billable_default
+        - test_data
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          maxLength: 100
+          example: 'Hotel Bergblick'
+        number:
+          description: 'Freely selectable number for the customer'
+          type:
+            - string
+            - 'null'
+          maxLength: 50
+          example: '10'
+        color:
+          $ref: '#/components/schemas/CustomerColor'
+        active:
+          type: boolean
+        billable_default:
+          type: boolean
+        note:
+          description: 'Only visible for administrators or workers with elevated access `manage_customers_and_projects`'
+          type:
+            - string
+            - 'null'
+          maxLength: 1000
+          example: 'This customer is important for us'
+        bill_service_id:
+          description: 'Only visible for administrators or workers with elevated access `manage_customers_and_projects` and if a billing application with customers support is linked up'
+          type:
+            - string
+            - 'null'
+          example: '1234'
+        test_data:
+          type: boolean
+        service_assignments:
+          type: array
+          items:
+            type: integer
+            format: int64
+            example: 10
+      type: object
+    CustomerColor:
+      title: 'Customer color'
+      description: "Possible values:\n- `1`: BloodOrange\n- `2`: Sunflower\n- `3`: LightGreen\n- `4`: Caribbean\n- `5`: Sky\n- `6`: BrandBlue\n- `7`: BluePurple\n- `8`: Magenta\n- `9`: ChewingGum"
+      type: integer
+      enum:
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+      x-enumNames:
+        - BloodOrange
+        - Sunflower
+        - LightGreen
+        - Caribbean
+        - Sky
+        - BrandBlue
+        - BluePurple
+        - Magenta
+        - ChewingGum
+    customer_projects_access_v2:
+      required:
+        - add
+        - report
+        - edit
+      properties:
+        add:
+          example: true
+          oneOf:
+            -
+              $ref: '#/components/schemas/general_access_v2'
+            -
+              $ref: '#/components/schemas/custom_access_v2'
+        report:
+          example:
+            '123': true
+            '456': true
+          oneOf:
+            -
+              $ref: '#/components/schemas/general_access_v2'
+            -
+              $ref: '#/components/schemas/custom_access_v2'
+        edit:
+          example:
+            '123': true
+            '456':
+              projects:
+                '789': true
+          oneOf:
+            -
+              $ref: '#/components/schemas/general_access_v2'
+            -
+              $ref: '#/components/schemas/custom_access_v2'
+      type: object
+    CustomerProjectScope:
+      title: 'Customer project scope'
+      description: "Possible values:\n- `manageAccess`: ManageAccess"
+      type: string
+      enum:
+        - manageAccess
+      x-enumNames:
+        - ManageAccess
+    DayAbsenceType:
+      title: 'Day absence type'
+      description: "Possible values:\n- `1`: Holiday from the quota\n- `2`: Special leaves\n- `4`: Sick day\n- `5`: Sick day of a child\n- `6`: School / further education\n- `7`: Maternity protection\n- `8`: Home office (planned hours get applied)\n- `9`: Work out of office (planned hours get applied)\n- `10`: Special leaves (unpaid)\n- `11`: Sick day (unpaid)\n- `12`: Sick day of a child (unpaid)\n- `13`: Quarantine (work not possible)\n- `14`: Military / alternative service\n- `15`: Sick day (sickness benefit)"
+      type: integer
+      enum:
+        - 1
+        - 2
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+      x-enumNames:
+        - RegularHoliday
+        - SpecialLeave
+        - SickSelf
+        - SickChild
+        - School
+        - MaternityProtection
+        - HomeOffice
+        - OutOfOffice
+        - SpecialLeaveUnpaid
+        - SickSelfUnpaid
+        - SickChildUnpaid
+        - Quarantine
+        - MilitaryService
+        - SickSelfWithCertificate
+    DeleteCompanyDefaultIsNotAllowedError:
+      title: 'Delete company default is not allowed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - DeleteCompanyDefaultIsNotAllowed
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'It is not allowed to delete a resource which is company default.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    DisableSubprojectAsWorkerIsForbiddenError:
+      title: 'Disable subproject as worker is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - DisableSubprojectAsWorkerIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: "You aren't allowed to archive subprojects."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    DuplicateEntryForUserAndYearError:
+      title: 'Duplicate entry for user and year error'
+      properties:
+        type:
+          type: string
+          enum:
+            - DuplicateEntryForUserAndYear
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'A resource has already been defined for this user and year.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    ClockDurationV2:
+      title: 'Edit clocked duration response'
+      required:
+        - updated
+        - running
+        - overlapping_correction
+        - current_time
+      properties:
+        updated:
+          $ref: '#/components/schemas/EntryV2'
+        running:
+          oneOf:
+            -
+              $ref: '#/components/schemas/EntryV2'
+            -
+              type: 'null'
+          type: object
+        overlapping_correction:
+          required:
+            - overlapping
+            - overlapping_free_time_since
+            - truncate_previous_entry
+          properties:
+            overlapping:
+              type: boolean
+              example: true
+            overlapping_free_time_since:
+              type:
+                - string
+                - 'null'
+              format: date-time
+              example: '2023-02-28T00:00:00Z'
+            truncate_previous_entry:
+              type:
+                - integer
+                - 'null'
+              format: int64
+              example: 1
+          type:
+            - object
+            - 'null'
+        current_time:
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+      type: object
+    EditInactiveSubprojectAsWorkerIsForbiddenError:
+      title: 'Edit inactive subproject as worker is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - EditInactiveSubprojectAsWorkerIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'This subproject has been archived and can only be reactivated by a co-worker with elevated access rights.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    EditLockDay:
+      title: 'Edit lock day'
+      description: "Possible values:\n- `1`: LockDays1\n- `2`: LockDays2\n- `3`: LockDays3\n- `5`: LockDays5\n- `8`: LockDays8\n- `15`: LockDays15\n- `31`: LockDays31\n- `46`: LockDays46\n- `91`: LockDays91"
+      type: integer
+      enum:
+        - 1
+        - 2
+        - 3
+        - 5
+        - 8
+        - 15
+        - 31
+        - 46
+        - 91
+      x-enumNames:
+        - LockDays1
+        - LockDays2
+        - LockDays3
+        - LockDays5
+        - LockDays8
+        - LockDays15
+        - LockDays31
+        - LockDays46
+        - LockDays91
+    EitherCustomersOrProjectsError:
+      title: 'Either customers or projects error'
+      properties:
+        type:
+          type: string
+          enum:
+            - EitherCustomersOrProjects
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    EmailNotAvailableError:
+      title: 'Email not available error'
+      properties:
+        type:
+          type: string
+          enum:
+            - EmailNotAvailable
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Email is not available.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Resource'
+      type: object
+      x-error-category: BadRequest
+    EmptyError:
+      title: 'Empty error'
+      properties:
+        type:
+          type: string
+          enum:
+            - Empty
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Value is required and cannot be empty.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    EndBeforeStartError:
+      title: 'End before start error'
+      properties:
+        type:
+          type: string
+          enum:
+            - EndBeforeStart
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    entriesText_v3:
+      required:
+        - id
+        - label
+        - value
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        label:
+          type: string
+          example: test
+        value:
+          type: string
+          example: test
+      type: object
+    EntryV2:
+      title: Entry
+      oneOf:
+        -
+          $ref: '#/components/schemas/EntryV2Time'
+        -
+          $ref: '#/components/schemas/EntryV2LumpsumValue'
+        -
+          $ref: '#/components/schemas/EntryV2LumpsumService'
+    EntryGroupConfirmUpdateV2:
+      required:
+        - confirm_key
+        - affected_entries
+      properties:
+        confirm_key:
+          type: string
+        affected_entries:
+          type: integer
+          format: int64
+      type: object
+    EntryGroupNoRestrictionV2:
+      properties: {  }
+    EntryGroupRestrictionV2:
+      properties:
+        users_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        teams_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        customers_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        projects_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        subprojects_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        services_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        lumpsum_services_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        billable:
+          oneOf:
+            -
+              $ref: '#/components/schemas/Billable'
+            -
+              type: 'null'
+        entriesTexts_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        budget_type:
+          type:
+            - string
+            - 'null'
+      type: object
+    EntryGroupUpdateV2:
+      required:
+        - success
+        - edited_entries
+      properties:
+        success:
+          type: boolean
+        edited_entries:
+          type: integer
+          format: int64
+      type: object
+    EntryGroupV2:
+      required:
+        - group
+        - name
+        - duration
+        - restrictions
+        - revenue
+        - has_budget_revenues_billed
+        - has_budget_revenues_not_billed
+        - has_non_budget_revenues_billed
+        - has_non_budget_revenues_not_billed
+        - budget_used
+        - hourly_rate
+        - hourly_rate_is_equal_and_has_no_lumpsums
+        - grouped_by
+      properties:
+        group:
+          description: 'Identifier of the current group'
+          type: string
+        name:
+          description: 'Textual description of the current group'
+          type: string
+        duration:
+          description: 'Duration of all time entries of the group'
+          type: integer
+          format: int64
+        restrictions:
+          description: 'Restrictions that apply to the current group, except for the current grouped_by and time restrictions'
+          oneOf:
+            -
+              $ref: '#/components/schemas/EntryGroupNoRestrictionV2'
+            -
+              $ref: '#/components/schemas/EntryGroupRestrictionV2'
+            -
+              type: 'null'
+        revenue:
+          description: 'Revenue of all time entries in the group (only if necessary employee rights for the group)'
+          type: integer
+          format: int64
+        has_budget_revenues_billed:
+          description: 'Does the group have at least one time entry that uses the hard project budget and has already been billed? (only if necessary employee rights for the group)'
+          type: boolean
+        has_budget_revenues_not_billed:
+          description: 'Does the group have at least one time entry that uses a hard project budget and has not yet been billed? (Only if necessary employee rights for the group)'
+          type: boolean
+        has_non_budget_revenues_billed:
+          description: 'Does the group have at least one time entry that does not use a hard project budget and has already been billed? (Only if the necessary employee rights are assigned to the group)'
+          type: boolean
+        has_non_budget_revenues_not_billed:
+          description: 'Does the group have at least one time entry that does not use a hard project budget and has not yet been billed? (Only if necessary employee rights for the group)'
+          type: boolean
+        budget_used:
+          description: 'Was a fixed project budget used for at least one time entry? (Only if necessary employee rights for the group)'
+          type: boolean
+        hourly_rate:
+          description: 'Average hourly rate for the group (only if necessary employee rights for the group)'
+          type:
+            - number
+            - 'null'
+          format: float
+        hourly_rate_is_equal_and_has_no_lumpsums:
+          description: 'Is the hourly rate the same for all billable entries and does the group have no flat-rate entries? In this case, revenue can be calculated as follows: revenue = hourly_rate * duration. This is particularly useful for creating invoice items. (Only if the necessary employee rights for the group are available)'
+          type: boolean
+        sub_groups:
+          description: 'If multiple grouping criteria have been specified, the next level can be found here.'
+          type:
+            - array
+            - 'null'
+          items:
+            $ref: '#/components/schemas/EntryGroupV2'
+        grouped_by:
+          description: 'Grouping criterion of the current grouping level'
+          type: string
+      type: object
+    EntryTextMode:
+      title: 'Entry text mode'
+      description: "Possible values:\n- `add`: Add\n- `edit`: Edit\n- `reports`: Reports"
+      type: string
+      enum:
+        - add
+        - edit
+        - reports
+      x-enumNames:
+        - Add
+        - Edit
+        - Reports
+    ExitDateRequiresActiveUserError:
+      title: 'Exit date requires active user error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ExitDateRequiresActiveUser
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An exit date can only be set for active co-workers.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    ExpectedValues:
+      title: 'Expected values error details'
+      description: 'Only certain values are allowed.'
+      required:
+        - expected_values
+      properties:
+        expected_values:
+          title: 'Expected values'
+          description: 'One or more expected values'
+          type: array
+          items:
+            type: string
+          example:
+            - string
+            - integer
+      type: object
+    Fields:
+      title: 'Fields error details'
+      description: 'The names of invalid input fields'
+      required:
+        - fields
+      properties:
+        fields:
+          title: Fields
+          description: 'One or more invalid fields'
+          type: array
+          items:
+            type: string
+          example:
+            - type
+            - status
+      type: object
+    FieldsShouldBeEmptyError:
+      title: 'Fields should be empty error'
+      properties:
+        type:
+          type: string
+          enum:
+            - FieldsShouldBeEmpty
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'According to your other information, the following fields should be empty: type, status.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Fields'
+      type: object
+      x-error-category: BadRequest
+    ForbiddenChangeToCustomAccessError:
+      title: 'Forbidden change to custom access error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ForbiddenChangeToCustomAccess
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Change to selected access is only possible from yes.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ForbiddenError:
+      title: 'Forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - Forbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Access denied.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ForbiddenValueError:
+      title: 'Forbidden value error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ForbiddenValue
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/AllowedValues'
+      type: object
+      x-error-category: Forbidden
+    general_access_v2:
+      description: 'General access'
+      type: boolean
+    GeneralErrors:
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiErrors'
+      type: object
+    Grouping:
+      title: Grouping
+      description: "Possible values:\n- `billable`: Billable\n- `customers_id`: CustomersId\n- `day`: Day\n- `month`: Month\n- `is_lumpsum`: IsLumpSum\n- `lumpsum_services_id`: LumpSumServicesId\n- `projects_id`: ProjectsId\n- `services_id`: ServicesId\n- `subprojects_id`: SubprojectsId\n- `texts_id`: TextsId\n- `users_id`: UsersId\n- `week`: Week\n- `year`: Year"
+      type: string
+      enum:
+        - billable
+        - customers_id
+        - day
+        - month
+        - is_lumpsum
+        - lumpsum_services_id
+        - projects_id
+        - services_id
+        - subprojects_id
+        - texts_id
+        - users_id
+        - week
+        - year
+      x-enumNames:
+        - Billable
+        - CustomersId
+        - Day
+        - Month
+        - IsLumpSum
+        - LumpSumServicesId
+        - ProjectsId
+        - ServicesId
+        - SubprojectsId
+        - TextsId
+        - UsersId
+        - Week
+        - Year
+    HalfDayAbsenceTooLongError:
+      title: 'Half day absence too long error'
+      properties:
+        type:
+          type: string
+          enum:
+            - HalfDayAbsenceTooLong
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Absences of half a day may not extend over several days.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    HasToBeActiveError:
+      title: 'Has to be active error'
+      properties:
+        type:
+          type: string
+          enum:
+            - HasToBeActive
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The resource must be active.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Resource'
+      type: object
+      x-error-category: BadRequest
+    HasToBeInactiveError:
+      title: 'Has to be inactive error'
+      properties:
+        type:
+          type: string
+          enum:
+            - HasToBeInactive
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The resource must be inactive.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Resource'
+      type: object
+      x-error-category: BadRequest
+    HolidaysCarryV3:
+      required:
+        - id
+        - users_id
+        - year
+        - count
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        users_id:
+          type: integer
+          format: int64
+        year:
+          type: integer
+          format: int64
+        count:
+          title: 'Amount of carried holidays'
+          type: number
+          example: 5.5
+        note:
+          type:
+            - string
+            - 'null'
+          maxLength: 1000
+          example: 'Saved for spring vacation'
+      type: object
+    HolidaysQuotaV2:
+      required:
+        - id
+        - users_id
+        - year_since
+        - year_until
+        - count
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        users_id:
+          type: integer
+          format: int64
+          example: 20
+        year_since:
+          type: integer
+          format: int64
+          example: '2023'
+        year_until:
+          type:
+            - integer
+            - 'null'
+          format: int64
+          example: '2024'
+        count:
+          type: number
+          format: float
+          example: 3.5
+        note:
+          type:
+            - string
+            - 'null'
+          maxLength: 1000
+          example: 'Carryover from previous year'
+      type: object
+    HourAbsenceType:
+      title: 'Hour absence type'
+      description: "Possible values:\n- `3`: Reduction of overtime"
+      type: integer
+      enum:
+        - 3
+      x-enumNames:
+        - OverTimeReduction
+    IllegalChangeForCompletedProjectError:
+      title: 'Illegal change for completed project error'
+      properties:
+        type:
+          type: string
+          enum:
+            - IllegalChangeForCompletedProject
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The project has already been completed. The budget and deadline can't be changed."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Fields'
+      type: object
+      x-error-category: Forbidden
+    IntervalBudgetRequiresRetainerPlanError:
+      title: 'Interval budget requires retainer plan error'
+      properties:
+        type:
+          type: string
+          enum:
+            - IntervalBudgetRequiresRetainerPlan
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Interval budgets feature is not available in your current plan.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    IntervalChangeIsForbiddenForIntervalProjectsWithSubprojectsError:
+      title: 'Interval change is forbidden for interval projects with subprojects error'
+      properties:
+        type:
+          type: string
+          enum:
+            - IntervalChangeIsForbiddenForIntervalProjectsWithSubprojects
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Changing the interval is forbidden for interval projects with existing subprojects.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    IntervalSubprojectMustHaveBudgetError:
+      title: 'Interval subproject must have budget error'
+      properties:
+        type:
+          type: string
+          enum:
+            - IntervalSubprojectMustHaveBudget
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Subprojects in retainer projects must have a budget.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    InvalidCombinationError:
+      title: 'Invalid combination error'
+      properties:
+        type:
+          type: string
+          enum:
+            - InvalidCombination
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The combination of the provided data is invalid.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Fields'
+      type: object
+      x-error-category: BadRequest
+    InvalidDateError:
+      title: 'Invalid date error'
+      properties:
+        type:
+          type: string
+          enum:
+            - InvalidDate
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The given value is not an actual date.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    IsDefaultHolidaysCountError:
+      title: 'Is default holidays count error'
+      properties:
+        type:
+          type: string
+          enum:
+            - IsDefaultHolidaysCount
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'It is not allowed to delete a holidays quota which is user default.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    Language:
+      title: Language
+      description: "Possible values:\n- `en`: English\n- `fr`: French\n- `de`: German"
+      type: string
+      enum:
+        - en
+        - fr
+        - de
+      x-enumNames:
+        - English
+        - French
+        - German
+    LumpSumServiceV4:
+      title: 'Lump sum service'
+      required:
+        - id
+        - name
+        - price
+        - unit
+        - active
+        - number
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          maxLength: 100
+          example: 'Travel costs'
+        price:
+          description: 'Price per unit'
+          type: number
+          format: float
+          example: 80.25
+        unit:
+          type:
+            - string
+            - 'null'
+          maxLength: 6
+          example: km
+        active:
+          type: boolean
+          example: true
+        number:
+          description: 'Lump sum service number'
+          type:
+            - string
+            - 'null'
+          maxLength: 50
+          example: Travel-123
+        note:
+          description: 'Only visible for administrators or workers with elevated access `manage_services`'
+          type:
+            - string
+            - 'null'
+          maxLength: 1000
+          example: 'Travel costs for the trip to the customer'
+      type: object
+    EntryV2LumpsumService:
+      title: 'Lumpsum Service Entry'
+      required:
+        - id
+        - customers_id
+        - projects_id
+        - subprojects_id
+        - users_id
+        - billable
+        - texts_id
+        - text
+        - time_since
+        - time_until
+        - time_insert
+        - time_last_change
+        - test_data
+        - type
+        - lumpsum_services_id
+        - lumpsum_services_amount
+      properties:
+        id:
+          title: ID
+          type: integer
+          format: int64
+          example: 10
+        customers_id:
+          title: "Customer's ID"
+          type: integer
+          format: int64
+          example: 10
+        projects_id:
+          title: "Project's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        subprojects_id:
+          title: "Subproject's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        users_id:
+          title: "User's ID"
+          type: integer
+          format: int64
+        billable:
+          title: 'is it billable?'
+          type: integer
+          format: int64
+        texts_id:
+          title: "Entry text's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        text:
+          title: Description
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+        time_since:
+          title: 'Start date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        time_until:
+          title: 'End date and time'
+          type:
+            - string
+            - 'null'
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        time_insert:
+          title: 'Insertion date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28Z00:00:00Z'
+        time_last_change:
+          title: 'Modification date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        test_data:
+          title: 'is a test dataset?'
+          type: boolean
+        customers_name:
+          title: "Customer's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'Hotel Bergblick'
+        projects_name:
+          title: "Project's name"
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+          example: 'Publicity campaign'
+        subprojects_name:
+          title: "Subproject's name"
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+          example: 'Social media ads'
+        users_name:
+          title: "User's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'Max Mustermann'
+        revenue:
+          title: Revenue
+          description: 'Only with necessary access rights and if enhanced_list=true'
+          type: number
+          example: 999.9
+        type:
+          title: Revenue
+          description: 'Entry type: 1 = time, 2 = lump sum value, 3 = lump sum service.'
+          type: number
+          enum:
+            - 3
+        services_name:
+          title: "Service's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'SEO service'
+        lumpsum_services_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        lumpsum_services_amount:
+          type: number
+          example: 99.99
+        lumpsum_services_price:
+          description: 'Only if enhanced_list=true'
+          type: number
+          example: 99.99
+      type: object
+    EntryV2LumpsumValue:
+      title: 'Lumpsum Value Entry'
+      required:
+        - id
+        - customers_id
+        - projects_id
+        - subprojects_id
+        - users_id
+        - billable
+        - texts_id
+        - text
+        - time_since
+        - time_until
+        - time_insert
+        - time_last_change
+        - test_data
+        - type
+        - services_id
+        - lumpsum
+      properties:
+        id:
+          title: ID
+          type: integer
+          format: int64
+          example: 10
+        customers_id:
+          title: "Customer's ID"
+          type: integer
+          format: int64
+          example: 10
+        projects_id:
+          title: "Project's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        subprojects_id:
+          title: "Subproject's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        users_id:
+          title: "User's ID"
+          type: integer
+          format: int64
+        billable:
+          title: 'is it billable?'
+          type: integer
+          format: int64
+        texts_id:
+          title: "Entry text's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        text:
+          title: Description
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+        time_since:
+          title: 'Start date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        time_until:
+          title: 'End date and time'
+          type:
+            - string
+            - 'null'
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        time_insert:
+          title: 'Insertion date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28Z00:00:00Z'
+        time_last_change:
+          title: 'Modification date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        test_data:
+          title: 'is a test dataset?'
+          type: boolean
+        customers_name:
+          title: "Customer's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'Hotel Bergblick'
+        projects_name:
+          title: "Project's name"
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+          example: 'Publicity campaign'
+        subprojects_name:
+          title: "Subproject's name"
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+          example: 'Social media ads'
+        users_name:
+          title: "User's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'Max Mustermann'
+        revenue:
+          title: Revenue
+          description: 'Only with necessary access rights and if enhanced_list=true'
+          type: number
+          example: 999.9
+        type:
+          title: Revenue
+          description: 'Entry type: 1 = time, 2 = lump sum value, 3 = lump sum service.'
+          type: number
+          enum:
+            - 2
+        services_id:
+          title: "Service's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        lumpsum:
+          type: number
+          example: 99.99
+        services_name:
+          title: "Service's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'SEO service'
+      type: object
+    MailCannotBeChangedError:
+      title: 'Mail cannot be changed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - MailCannotBeChanged
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Changing the e-mail address of co-workers is disabled in Clockodo. Please use your towio account for this instead. The data will be synchronized.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/MailCannotBeChangedErrorDetails'
+      type: object
+      x-error-category: Forbidden
+    MailCannotBeChangedErrorDetails:
+      required:
+        - reason
+      properties:
+        reason:
+          type: string
+      type: object
+    MaxUsersOfPlanTypeReachedError:
+      title: 'Max users of plan type reached error'
+      properties:
+        type:
+          type: string
+          enum:
+            - MaxUsersOfPlanTypeReached
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You have reached the maximum number of co-workers included in your subscription. Please upgrade your plan in the payment section.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    MaxUsersReachedError:
+      title: 'Max users reached error'
+      properties:
+        type:
+          type: string
+          enum:
+            - MaxUsersReached
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You have reached the maximum number of co-workers included in your subscription. Please update your subscription in the payment section.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    MenuIcon:
+      title: 'Menu icon'
+      description: "Possible values:\n- `briefcase`: Briefcase\n- `chart-bar`: ChartBar\n- `code`: Code\n- `cog`: Cog\n- `holiday`: Holiday\n- `home`: Home\n- `folder-open`: FolderOpen\n- `planner`: Planner\n- `plus-circle`: PlusCircle\n- `share`: Share\n- `star`: Star\n- `stopwatch`: Stopwatch\n- `team-holiday`: TeamHoliday\n- `template`: Template\n- `timetable`: Timetable\n- `user-group`: UserGroup\n- `user-holiday`: UserHoliday\n- `users`: Users"
+      type: string
+      enum:
+        - briefcase
+        - chart-bar
+        - code
+        - cog
+        - holiday
+        - home
+        - folder-open
+        - planner
+        - plus-circle
+        - share
+        - star
+        - stopwatch
+        - team-holiday
+        - template
+        - timetable
+        - user-group
+        - user-holiday
+        - users
+      x-enumNames:
+        - Briefcase
+        - ChartBar
+        - Code
+        - Cog
+        - Holiday
+        - Home
+        - FolderOpen
+        - Planner
+        - PlusCircle
+        - Share
+        - Star
+        - Stopwatch
+        - TeamHoliday
+        - Template
+        - Timetable
+        - UserGroup
+        - UserHoliday
+        - Users
+    MissingManageUsersAccessError:
+      title: 'Missing manage users access error'
+      properties:
+        type:
+          type: string
+          enum:
+            - MissingManageUsersAccess
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You are not allowed to edit or delete access groups with elevated access.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    MissingManageUsersAccessForAssigningAccessGroupError:
+      title: 'Missing manage users access for assigning access group error'
+      properties:
+        type:
+          type: string
+          enum:
+            - MissingManageUsersAccessForAssigningAccessGroup
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You are not allowed to assign groups with elevated access to users.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/MissingManageUsersAccessForAssigningAccessGroup'
+      type: object
+      x-error-category: Forbidden
+    MissingManageUsersAccessForRemovingAccessGroupError:
+      title: 'Missing manage users access for removing access group error'
+      properties:
+        type:
+          type: string
+          enum:
+            - MissingManageUsersAccessForRemovingAccessGroup
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You are not allowed to remove groups with elevated access from users.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/MissingManageUsersAccessForRemovingAccessGroup'
+      type: object
+      x-error-category: Forbidden
+    NonbusinessDayType:
+      title: 'Nonbusiness day type'
+      description: "Possible values:\n- `SPECIAL`: Special\n- `DISTINCT_ONCE`: DistinctOnce\n- `DISTINCT_RECURRING`: DistinctRecurring"
+      type: string
+      enum:
+        - SPECIAL
+        - DISTINCT_ONCE
+        - DISTINCT_RECURRING
+      x-enumNames:
+        - Special
+        - DistinctOnce
+        - DistinctRecurring
+    NonbusinessDayV2:
+      required:
+        - id
+        - nonbusiness_group_id
+        - type
+        - name
+        - half_day
+        - surcharge_special
+        - evaluated_date
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        nonbusiness_group_id:
+          type: integer
+          format: int64
+          example: 504
+        type:
+          $ref: '#/components/schemas/NonbusinessDayType'
+        name:
+          type: string
+          example: 'Tag der deutschen Einheit'
+        half_day:
+          type: boolean
+          example: true
+        surcharge_special:
+          type: boolean
+          example: true
+        special_id:
+          type: integer
+          format: int64
+          example: 64
+        evaluated_date:
+          title: 'Evaluated date for the requested year'
+          description: 'Default: CurrentYear'
+          type: string
+          format: date
+          example: '2021-10-03'
+        day:
+          title: 'Day of the nonbusiness day'
+          description: 'only for types DISTINCT_ONCE and DISTINCT_RECURRING'
+          type: integer
+          format: int64
+          example: 3
+        month:
+          title: 'Month of the nonbusiness day'
+          description: 'only for types DISTINCT_ONCE and DISTINCT_RECURRING'
+          type: integer
+          format: int64
+          example: 10
+        year:
+          title: 'Year of the nonbusiness day'
+          description: 'only for type DISTINCT_ONCE'
+          type: integer
+          format: int64
+          example: 2021
+      type: object
+    NonbusinessGroupV2:
+      required:
+        - id
+        - name
+        - company_default
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          maxLength: 100
+          example: 'Nonbusiness days in NRW'
+        company_default:
+          type: boolean
+          example: false
+      type: object
+    NotBetweenError:
+      title: 'Not between error'
+      properties:
+        type:
+          type: string
+          enum:
+            - NotBetween
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/NotBetween'
+      type: object
+      x-error-category: BadRequest
+    NotBetween:
+      title: 'Not between error details'
+      description: 'The value is not between min and max'
+      required:
+        - min
+        - max
+        - inclusive
+      properties:
+        min:
+          title: 'Minimum value'
+          type: number
+          example: 0
+        max:
+          title: 'Maximum value'
+          type: number
+          example: 10000
+        inclusive:
+          title: 'Boundaries inclusive'
+          description: 'Are the minimum and maximum values allowed'
+          type: boolean
+          example: true
+      type: object
+    BudgetTotalErrorDetails:
+      title: 'Not between error details'
+      required:
+        - max
+        - budget_is_hours
+      properties:
+        max:
+          type: number
+          example: 10000
+        budget_is_hours:
+          type: boolean
+          example: true
+      type: object
+    OneOpenEndedQuotaError:
+      title: 'One open ended quota error'
+      properties:
+        type:
+          type: string
+          enum:
+            - OneOpenEndedQuota
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'There must be only one open ended holidays quota.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    OnlyOwnerCanDeleteOwnerError:
+      title: 'Only owner can delete owner error'
+      properties:
+        type:
+          type: string
+          enum:
+            - OnlyOwnerCanDeleteOwner
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Only administrators can delete administrators.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    OvertimeCarryV3:
+      title: 'Overtime carry'
+      required:
+        - id
+        - users_id
+        - year
+        - hours
+        - note
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        users_id:
+          type: integer
+          format: int64
+        year:
+          type: integer
+          format: int64
+          example: 2024
+        hours:
+          type: number
+          format: float
+          example: 5.5
+        note:
+          type:
+            - string
+            - 'null'
+          maxLength: 1000
+          example: 'Saved for spring'
+      type: object
+    OvertimeReductionV3:
+      title: 'Overtime reduction'
+      required:
+        - id
+        - users_id
+        - date
+        - hours
+        - note
+        - added_at
+        - added_by_users_id
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        users_id:
+          type: integer
+          format: int64
+        date:
+          type: string
+          format: date
+          example: '2023-02-28'
+        hours:
+          type: number
+          example: 5.5
+        note:
+          type:
+            - string
+            - 'null'
+          maxLength: 1000
+          example: 'Visiting authorities'
+        added_at:
+          type: string
+          format: date
+          example: '2023-02-28'
+        added_by_users_id:
+          type: integer
+          format: int64
+          example: 10
+      type: object
+    ParentOverwriteIsForbiddenError:
+      title: 'Parent overwrite is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ParentOverwriteIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ProjectBudgetV4:
+      required:
+        - monetary
+        - hard
+        - from_subprojects
+        - interval
+        - amount
+        - subprojects_budget_total
+      properties:
+        monetary:
+          type: boolean
+        hard:
+          type: boolean
+        from_subprojects:
+          type: boolean
+        interval:
+          oneOf:
+            -
+              $ref: '#/components/schemas/BudgetInterval'
+            -
+              type: 'null'
+        amount:
+          type:
+            - number
+            - 'null'
+          format: float
+        subprojects_budget_total:
+          type: number
+          format: float
+        notification_thresholds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Thresholds'
+      type: object
+    ProjectCompletionAnyRunningEntriesError:
+      title: 'Project completion any running entries error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ProjectCompletionAnyRunningEntries
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The project can't be set to completed. A co-worker is currently tracking time with the clock."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ProjectCompletionNoBillableEntriesError:
+      title: 'Project completion no billable entries error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ProjectCompletionNoBillableEntries
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The project can't be set to completed. At least one billable entry is required."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ProjectCompletionTooManyLumpSumsError:
+      title: 'Project completion too many lump sums error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ProjectCompletionTooManyLumpSums
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The project can't be set to completed. The sum of billable lump sums must not exceed the budget."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ProjectDeadlineIsNotBeforeProjectStartError:
+      title: 'Project deadline is not before project start error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ProjectDeadlineIsNotBeforeProjectStart
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Deadline must be after or equal to start date.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    ProjectIsCompletedError:
+      title: 'Project is completed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ProjectIsCompleted
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The project is completed.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ProjectPeriodCollidesWithSubprojectPeriodsError:
+      title: 'Project period collides with subproject periods error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ProjectPeriodCollidesWithSubprojectPeriods
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The project period collides with one or more subproject periods.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    ProjectPeriodMustContainAllEntryStartsError:
+      title: 'Project period must contain all entry starts error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ProjectPeriodMustContainAllEntryStarts
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Project period must contain all entry dates.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    ProjectReportsV3:
+      required:
+        - customers_id
+        - customers_name
+        - customers_number
+        - projects_id
+        - projects_name
+        - projects_number
+      properties:
+        customers_id:
+          type: integer
+          format: int64
+          example: 10
+        customers_name:
+          type: string
+          maxLength: 100
+          example: 'Hotel Bergblick'
+        customers_number:
+          description: 'Freely selectable number for the customer'
+          type:
+            - string
+            - 'null'
+          maxLength: 50
+          example: 10
+        projects_id:
+          type: integer
+          format: int64
+          example: 10
+        projects_name:
+          type: string
+          maxLength: 100
+          example: Werbekampagne
+        projects_number:
+          description: 'Freely selectable number for the project'
+          type:
+            - string
+            - 'null'
+          maxLength: 50
+          example: 10
+      type: object
+    ProjectsReportProjectReportItemV4:
+      required:
+        - customers_id
+        - customers_name
+        - customers_number
+        - projects_id
+        - projects_name
+        - projects_number
+      properties:
+        customers_id:
+          type: integer
+          format: int64
+        customers_name:
+          type: string
+        customers_number:
+          type:
+            - string
+            - 'null'
+        projects_id:
+          type: integer
+          format: int64
+        projects_name:
+          type: string
+        projects_number:
+          type:
+            - string
+            - 'null'
+      type: object
+    ProjectsReportReportItemV4:
+      oneOf:
+        -
+          $ref: '#/components/schemas/ProjectsReportProjectReportItemV4'
+        -
+          $ref: '#/components/schemas/ProjectsReportRetainerSubprojectReportItemV4'
+    ProjectsReportRetainerSubprojectReportItemV4:
+      required:
+        - customers_id
+        - customers_name
+        - customers_number
+        - projects_id
+        - projects_name
+        - projects_number
+        - subprojects_id
+        - subprojects_name
+        - subprojects_number
+      properties:
+        customers_id:
+          type: integer
+          format: int64
+        customers_name:
+          type: string
+        customers_number:
+          type:
+            - string
+            - 'null'
+        projects_id:
+          type: integer
+          format: int64
+        projects_name:
+          type: string
+        projects_number:
+          type:
+            - string
+            - 'null'
+        subprojects_id:
+          type: integer
+          format: int64
+        subprojects_name:
+          type: string
+        subprojects_number:
+          type:
+            - string
+            - 'null'
+      type: object
+    ProjectV4:
+      required:
+        - id
+        - customers_id
+        - name
+        - number
+        - active
+        - billable_default
+        - completed
+        - completed_at
+        - test_data
+        - count_subprojects
+        - service_assignments
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        customers_id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          example: 'Publicity campaign'
+        number:
+          title: 'Freely selectable number for the project'
+          type:
+            - string
+            - 'null'
+        active:
+          type: boolean
+        billable_default:
+          type: boolean
+        note:
+          description: 'Only with necessary access rights'
+          type:
+            - string
+            - 'null'
+          example: 'This project is important for us'
+        billed_money:
+          title: 'Billed amount of money'
+          description: 'Only with necessary access rights'
+          type:
+            - number
+            - 'null'
+          format: float
+        billed_completely:
+          description: 'Only with necessary access rights'
+          type:
+            - boolean
+            - 'null'
+        completed:
+          type: boolean
+        completed_at:
+          title: 'Date and time when the project was completed'
+          type:
+            - string
+            - 'null'
+          format: date-time
+          example: '2023-02-28T12:00:00Z'
+        revenue_factor:
+          title: 'Factor by which revenues and hourly rates must be multiplied to obtain the effective values'
+          description: 'Only with necessary access rights.\n`null` for a project with hard budget that hasn''t been completed yet.\nFor a project with hard budget which has been completed with a budget usage of 400%, the factor is `0.25`.\n`1` for projects without budget or with soft budget.'
+          type:
+            - number
+            - 'null'
+          format: float
+        deadline:
+          title: 'Date when the project will be completed automatically if automatic_completion is enabled'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2023-02-28'
+        start_date:
+          description: 'Date when the project becomes available for time tracking'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2023-01-01'
+        automatic_completion:
+          description: 'Whether the project will be completed automatically when the deadline is reached'
+          type: boolean
+        test_data:
+          type: boolean
+        count_subprojects:
+          description: 'Number of subprojects'
+          type: integer
+          format: int64
+          example: 5
+        budget:
+          oneOf:
+            -
+              $ref: '#/components/schemas/ProjectBudgetV4'
+            -
+              type: 'null'
+        bill_service_id:
+          type:
+            - string
+            - 'null'
+          example: '1234'
+        service_assignments:
+          type: array
+          items:
+            type: integer
+            format: int64
+          example:
+            - 10
+      type: object
+    RateV3:
+      title: Rate
+      required:
+        - id
+        - customer_ids
+        - project_ids
+        - service_ids
+        - user_ids
+        - hourly_rate
+        - test_data
+        - children
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        customer_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+            example: 10
+          example:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+        project_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+            example: 10
+          example:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+        service_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+            example: 10
+          example:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+        user_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+            example: 10
+          example:
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+        hourly_rate:
+          type: number
+          format: float
+          example: 99.99
+        test_data:
+          type: boolean
+          example: false
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/RateV3'
+          example: []
+      type: object
+    RateAlreadyExistsError:
+      title: 'Rate already exists error'
+      properties:
+        type:
+          type: string
+          enum:
+            - RateAlreadyExists
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    RatesDefaultV4:
+      required:
+        - hourly_rate
+      properties:
+        hourly_rate:
+          type: number
+          format: float
+      type: object
+    RatesSortV4:
+      required:
+        - success
+      properties:
+        success:
+          type: boolean
+      type: object
+    RateV4:
+      required:
+        - id
+        - parent_rate_id
+        - customer_ids
+        - project_ids
+        - service_ids
+        - user_ids
+        - hourly_rate
+        - test_data
+        - position
+      properties:
+        id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        parent_rate_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        customer_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+        project_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+        service_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+        user_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+        hourly_rate:
+          type: number
+          format: float
+        test_data:
+          type: boolean
+        position:
+          type: integer
+          format: int64
+      type: object
+    RegisterV1:
+      required:
+        - success
+        - user
+        - apikey
+        - first_login_key
+      properties:
+        success:
+          type: boolean
+        user:
+          $ref: '#/components/schemas/SettingV1'
+        apikey:
+          type: string
+        first_login_key:
+          type:
+            - string
+            - 'null'
+      type: object
+    RelationsPreventDeletionError:
+      title: 'Relations prevent deletion error'
+      properties:
+        type:
+          type: string
+          enum:
+            - RelationsPreventDeletion
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Resource can not be deleted, there are existing relations. Please delete the related resources first.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Resource'
+      type: object
+      x-error-category: Forbidden
+    RequiresBudgetError:
+      title: 'Requires budget error'
+      properties:
+        type:
+          type: string
+          enum:
+            - RequiresBudget
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'A budget is required when budget type is hard.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    Resource:
+      required:
+        - resources
+      properties:
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceEnum'
+        count:
+          type: array
+          items:
+            type: integer
+      type: object
+    ResourceConflictFoundError:
+      title: 'Resource conflict found error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ResourceConflictFound
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'There is already a service with this name.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/Resource'
+      type: object
+      x-error-category: BadRequest
+    ResourceEnum:
+      title: 'Resource enum'
+      description: "Possible values:\n- `absences`: Absences\n- `access_groups`: AccessGroups\n- `company`: Company\n- `company_state`: CompanyState\n- `customers`: Customers\n- `entries`: Entries\n- `favorite`: Favorite\n- `holidays_carry`: HolidaysCarry\n- `holidays_quota`: HolidaysQuota\n- `lumpsum_services`: LumpSumServices\n- `nonbusiness_days`: NonBusinessDays\n- `nonbusiness_groups`: NonBusinessGroups\n- `overtime_carrys`: OvertimeCarrys\n- `project_reports`: ProjectReports\n- `project_reports_meta_data`: ProjectReportsMetaData\n- `projects`: Projects\n- `rates`: Rates\n- `reports`: Reports\n- `report_templates`: ReportTemplates\n- `services`: Services\n- `subprojects`: Subprojects\n- `surcharge_models`: SurchargeModels\n- `users`: Users\n- `customers_projects_access`: CustomersProjectsAccess\n- `targethours`: TargetHours\n- `team`: Teams\n- `work_time_break_rules`: WorkTimeBreakRules\n- `work_time_regulations`: WorkTimeRegulations"
+      type: string
+      enum:
+        - absences
+        - access_groups
+        - company
+        - company_state
+        - customers
+        - entries
+        - favorite
+        - holidays_carry
+        - holidays_quota
+        - lumpsum_services
+        - nonbusiness_days
+        - nonbusiness_groups
+        - overtime_carrys
+        - project_reports
+        - project_reports_meta_data
+        - projects
+        - rates
+        - reports
+        - report_templates
+        - services
+        - subprojects
+        - surcharge_models
+        - users
+        - customers_projects_access
+        - targethours
+        - team
+        - work_time_break_rules
+        - work_time_regulations
+      x-enumNames:
+        - Absences
+        - AccessGroups
+        - Company
+        - CompanyState
+        - Customers
+        - Entries
+        - Favorite
+        - HolidaysCarry
+        - HolidaysQuota
+        - LumpSumServices
+        - NonBusinessDays
+        - NonBusinessGroups
+        - OvertimeCarrys
+        - ProjectReports
+        - ProjectReportsMetaData
+        - Projects
+        - Rates
+        - Reports
+        - ReportTemplates
+        - Services
+        - Subprojects
+        - SurchargeModels
+        - Users
+        - CustomersProjectsAccess
+        - TargetHours
+        - Teams
+        - WorkTimeBreakRules
+        - WorkTimeRegulations
+    ResourceNotFoundError:
+      title: 'Resource not found error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ResourceNotFound
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The requested resource could not be found.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    ResourcesInactiveError:
+      title: 'Resources inactive error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ResourcesInactive
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The requested resources are inactive.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/ResourcesInactive'
+      type: object
+      x-error-category: BadRequest
+    ResourcesInactive:
+      title: 'Resources inactive error details'
+      required:
+        - inactive_ids
+      properties:
+        inactive_ids:
+          title: 'Inactive resources'
+          description: 'One or more ids of inactive resources'
+          type: array
+          items:
+            type: integer
+          example:
+            - 99999
+      type: object
+    ResourcesNotFoundError:
+      title: 'Resources not found error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ResourcesNotFound
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The requested resources could not be found.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/ResourcesNotFound'
+      type: object
+      x-error-category: BadRequest
+    ResourcesNotFound:
+      title: 'Resources not found error details'
+      required:
+        - not_found_ids
+      properties:
+        not_found_ids:
+          title: 'Not found resources'
+          description: 'One or more ids of missing resources'
+          type: array
+          items:
+            type: integer
+          example:
+            - 99999
+      type: object
+    Role:
+      title: Role
+      description: "Possible values:\n- `worker`: Worker\n- `owner`: Administrator"
+      type: string
+      enum:
+        - worker
+        - owner
+      x-enumNames:
+        - Worker
+        - Owner
+    RunningEntriesPreventArchivingError:
+      title: 'Running entries prevent archiving error'
+      properties:
+        type:
+          type: string
+          enum:
+            - RunningEntriesPreventArchiving
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Resource can not be archived, there are running entries. Please stop those entries first.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    RunningEntriesPreventDeletionError:
+      title: 'Running entries prevent deletion error'
+      properties:
+        type:
+          type: string
+          enum:
+            - RunningEntriesPreventDeletion
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Resource can not be deleted, there are running entries. Please stop and delete those entries first.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    ServiceDoesNotExistError:
+      title: 'Service does not exist error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ServiceDoesNotExist
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'At least one requested service does not exist.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/ServiceDoesNotExist'
+      type: object
+      x-error-category: BadRequest
+    ServiceDoesNotExist:
+      title: 'Service does not exist error details'
+      properties:
+        non_existent_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+      type: object
+    services_access_v2:
+      required:
+        - add
+      properties:
+        add:
+          example:
+            '123': true
+            '456': true
+          oneOf:
+            -
+              $ref: '#/components/schemas/general_access_v2'
+            -
+              description: 'Access to selected services'
+              type: object
+              additionalProperties:
+                description: 'Key value pairs in the format {service id} => true'
+                type: boolean
+                enum:
+                  - true
+      type: object
+    ServiceScope:
+      title: 'Service scope'
+      description: "Possible values:\n- `manageAccess`: ManageAccess"
+      type: string
+      enum:
+        - manageAccess
+      x-enumNames:
+        - ManageAccess
+    ServiceV4:
+      required:
+        - id
+        - name
+        - number
+        - active
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          maxLength: 100
+          example: Repair
+        number:
+          title: 'Freely selectable number for the service'
+          type:
+            - string
+            - 'null'
+          maxLength: 50
+          example: SRV-123
+        active:
+          type: boolean
+        note:
+          description: 'Only visible for administrators or workers with elevated access `manage_services`'
+          type:
+            - string
+            - 'null'
+          maxLength: 1000
+          example: 'Repair cost for the customer'
+        bill_service_id:
+          description: 'Only visible for administrators or workers with elevated access `manage_services` and `manage_addons` and if a billing application with services support is linked up'
+          type:
+            - string
+            - 'null'
+          example: '1234'
+      type: object
+    SettingAccessV1:
+      required:
+        - addCustomers
+      properties:
+        addCustomers:
+          type: boolean
+      type: object
+    SettingPriceFormatV1:
+      required:
+        - example
+        - format
+      properties:
+        example:
+          type: number
+          format: float
+        format:
+          type: string
+      type: object
+    SettingV1:
+      required:
+        - name
+        - email
+        - role
+        - access
+        - price_format
+        - timeformat_12h
+        - weekstart_monday
+        - weekend_friday
+        - language
+        - currency
+        - currency_symbol
+        - timezone
+        - support_pin
+        - allowEntriesTextMultiline
+        - show_favorites
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+        role:
+          $ref: '#/components/schemas/Role'
+        access:
+          $ref: '#/components/schemas/SettingAccessV1'
+        price_format:
+          $ref: '#/components/schemas/SettingPriceFormatV1'
+        timeformat_12h:
+          type: boolean
+        weekstart_monday:
+          type: boolean
+        weekend_friday:
+          type: boolean
+        language:
+          $ref: '#/components/schemas/Language'
+        currency:
+          type: string
+        currency_symbol:
+          type: string
+        timezone:
+          type: string
+        support_pin:
+          type: string
+        allowEntriesTextMultiline:
+          type: boolean
+        show_favorites:
+          type: boolean
+      type: object
+    ShouldNotHaveBudgetError:
+      title: 'Should not have budget error'
+      properties:
+        type:
+          type: string
+          enum:
+            - ShouldNotHaveBudget
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'This subproject cannot have a budget, as it belongs to a project without budget.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    SimpleErrors:
+      title: 'Simple error'
+      required:
+        - code
+        - message
+      properties:
+        code:
+          description: 'HTTP status code'
+          type: integer
+        message:
+          description: 'An error occurred'
+          type: string
+        fields:
+          description: 'Affected fields'
+          type: array
+          items:
+            type: string
+      type: object
+    SimpleErrorResponses:
+      title: 'Simple error response'
+      properties:
+        error:
+          $ref: '#/components/schemas/SimpleErrors'
+          description: 'Service zum Auslesen des OpenApi-Attributs für das Multi-Error-Format'
+      type: object
+    ApiProjectsReportsV3_SortForIndex:
+      title: 'Sort for index'
+      description: "Possible values:\n- `customers_name`: CustomersNameAsc\n- `-customers_name`: CustomersNameDesc\n- `projects_name`: ProjectsNameAsc\n- `-projects_name`: ProjectsNameDesc"
+      type: string
+      enum:
+        - customers_name
+        - '-customers_name'
+        - projects_name
+        - '-projects_name'
+      x-enumNames:
+        - CustomersNameAsc
+        - CustomersNameDesc
+        - ProjectsNameAsc
+        - ProjectsNameDesc
+    ApiProjectsReportsV4_SortForIndex:
+      title: 'Sort for index'
+      description: "Possible values:\n- `customers_name`: CustomersNameAsc\n- `-customers_name`: CustomersNameDesc\n- `projects_name`: ProjectsNameAsc\n- `-projects_name`: ProjectsNameDesc\n- `subprojects_name`: SubprojectsNameAsc\n- `-subprojects_name`: SubprojectsNameDesc"
+      type: string
+      enum:
+        - customers_name
+        - '-customers_name'
+        - projects_name
+        - '-projects_name'
+        - subprojects_name
+        - '-subprojects_name'
+      x-enumNames:
+        - CustomersNameAsc
+        - CustomersNameDesc
+        - ProjectsNameAsc
+        - ProjectsNameDesc
+        - SubprojectsNameAsc
+        - SubprojectsNameDesc
+    ApiUsersV3_SortForIndex:
+      title: 'Sort for index'
+      description: "Possible values:\n- `active`: ActiveAsc\n- `-active`: ActiveDesc\n- `id`: IdAsc\n- `-id`: IdDesc\n- `name`: NameAsc\n- `-name`: NameDesc\n- `number`: NumberAsc\n- `-number`: NumberDesc\n- `role`: RoleAsc\n- `-role`: RoleDesc\n- `teams_name`: TeamsNameAsc\n- `-teams_name`: TeamsNameDesc"
+      type: string
+      enum:
+        - active
+        - '-active'
+        - id
+        - '-id'
+        - name
+        - '-name'
+        - number
+        - '-number'
+        - role
+        - '-role'
+        - teams_name
+        - '-teams_name'
+      x-enumNames:
+        - ActiveAsc
+        - ActiveDesc
+        - IdAsc
+        - IdDesc
+        - NameAsc
+        - NameDesc
+        - NumberAsc
+        - NumberDesc
+        - RoleAsc
+        - RoleDesc
+        - TeamsNameAsc
+        - TeamsNameDesc
+    SortIdDate:
+      title: 'Sort id date'
+      description: "Possible values:\n- `date`: DateAsc\n- `-date`: DateDesc\n- `id`: IdAsc\n- `-id`: IdDesc"
+      type: string
+      enum:
+        - date
+        - '-date'
+        - id
+        - '-id'
+      x-enumNames:
+        - DateAsc
+        - DateDesc
+        - IdAsc
+        - IdDesc
+    SortIdName:
+      title: 'Sort id name'
+      description: "Possible values:\n- `id`: IdAsc\n- `-id`: IdDesc\n- `name`: NameAsc\n- `-name`: NameDesc"
+      type: string
+      enum:
+        - id
+        - '-id'
+        - name
+        - '-name'
+      x-enumNames:
+        - IdAsc
+        - IdDesc
+        - NameAsc
+        - NameDesc
+    SortIdNameActive:
+      title: 'Sort id name active'
+      description: "Possible values:\n- `active`: ActiveAsc\n- `-active`: ActiveDesc\n- `id`: IdAsc\n- `-id`: IdDesc\n- `name`: NameAsc\n- `-name`: NameDesc"
+      type: string
+      enum:
+        - active
+        - '-active'
+        - id
+        - '-id'
+        - name
+        - '-name'
+      x-enumNames:
+        - ActiveAsc
+        - ActiveDesc
+        - IdAsc
+        - IdDesc
+        - NameAsc
+        - NameDesc
+    SsoPreventsDeactivationError:
+      title: 'Sso prevents deactivation error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SsoPreventsDeactivation
+        message:
+          type:
+            - string
+            - 'null'
+          example: "This user account can't be deactivated because it is the main account of an add-on linkup."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    StatusIsForbiddenError:
+      title: 'Status is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - StatusIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The provided status is not available in this constellation.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectBudgetCommitmentNotEditableForBudgetSourceError:
+      title: 'Subproject budget commitment not editable for budget source error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectBudgetCommitmentNotEditableForBudgetSource
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Budget strictness cannot be edited for this budget source configuration.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectBudgetModificationIsProhibitedBecauseItIsCompletedError:
+      title: 'Subproject budget modification is prohibited because it is completed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectBudgetModificationIsProhibitedBecauseItIsCompleted
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot edit subproject budget data because the subproject is already completed.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectBudgetTypeNotEditableForBudgetSourceError:
+      title: 'Subproject budget type not editable for budget source error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectBudgetTypeNotEditableForBudgetSource
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Budget type cannot be edited for this budget source configuration.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectBudgetV3:
+      required:
+        - monetary
+        - hard
+        - amount
+      properties:
+        monetary:
+          type: boolean
+        hard:
+          type: boolean
+        amount:
+          type:
+            - number
+            - 'null'
+          format: float
+        notification_thresholds:
+          type: array
+          items:
+            $ref: '#/components/schemas/Thresholds'
+      type: object
+    SubprojectCompletionAnyRunningEntriesError:
+      title: 'Subproject completion any running entries error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectCompletionAnyRunningEntries
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The subproject can't be set to completed. A co-worker is currently tracking time with the clock."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectCompletionNoBillableEntriesError:
+      title: 'Subproject completion no billable entries error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectCompletionNoBillableEntries
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The subproject can't be set to completed. At least one billable entry is required."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectCompletionTooManyLumpSumsError:
+      title: 'Subproject completion too many lump sums error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectCompletionTooManyLumpSums
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The subproject can't be set to completed. The sum of billable lump sums must not exceed the budget."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectCompletionWithHardBudgetIsProhibitedForCompletedProjectsError:
+      title: 'Subproject completion with hard budget is prohibited for completed projects error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectCompletionWithHardBudgetIsProhibitedForCompletedProjects
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot complete a subproject with a hard budget because the project is completed.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectCreationWithBudgetIsProhibitedError:
+      title: 'Subproject creation with budget is prohibited error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectCreationWithBudgetIsProhibited
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'You cannot create a subproject with a budget because it is already completed.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectDeadlineIsNotBeforeSubprojectStartError:
+      title: 'Subproject deadline is not before subproject start error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectDeadlineIsNotBeforeSubprojectStart
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Deadline must be after or equal to start date.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    SubprojectIsCompletedError:
+      title: 'Subproject is completed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectIsCompleted
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The subproject is completed.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectPeriodIsNotWithinProjectsPeriodError:
+      title: 'Subproject period is not within projects period error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectPeriodIsNotWithinProjectsPeriod
+        message:
+          type:
+            - string
+            - 'null'
+          example: "The subproject's start date and deadline must be within the project's start date and deadline period."
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    SubprojectPeriodMustContainAllEntryStartsError:
+      title: 'Subproject period must contain all entry starts error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectPeriodMustContainAllEntryStarts
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Project period must contain all entry dates.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    SubprojectsCanNotBeSetToBilledError:
+      title: 'Subprojects can not be set to billed error'
+      properties:
+        type:
+          type: string
+          enum:
+            - SubprojectCanNotBeSetToBilled
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Subprojects can not be set to billed (except interval subprojects). Please set the parent project to billed.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    SubprojectV3:
+      required:
+        - id
+        - projects_id
+        - name
+        - number
+        - billed
+        - billed_money
+        - billed_completely
+        - billable_default
+        - completed
+        - completed_at
+        - start_date
+        - deadline
+        - active
+        - service_assignments
+      properties:
+        id:
+          type: integer
+        projects_id:
+          type: integer
+        name:
+          type: string
+        note:
+          type:
+            - string
+            - 'null'
+        number:
+          type:
+            - string
+            - 'null'
+        budget:
+          oneOf:
+            -
+              $ref: '#/components/schemas/SubprojectBudgetV3'
+            -
+              type: 'null'
+        billed:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        billed_money:
+          type:
+            - number
+            - 'null'
+          format: float
+        billed_completely:
+          type:
+            - boolean
+            - 'null'
+        billable_default:
+          type: boolean
+        completed:
+          type: boolean
+        completed_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        revenue_factor:
+          type:
+            - number
+            - 'null'
+          format: float
+        start_date:
+          type:
+            - string
+            - 'null'
+          format: date
+        deadline:
+          type:
+            - string
+            - 'null'
+          format: date
+        active:
+          type: boolean
+        automatic_completion:
+          type: boolean
+        service_assignments:
+          type: array
+          items:
+            type: integer
+            format: int64
+        bill_service_id:
+          type:
+            - string
+            - 'null'
+      type: object
+    subscription_v2:
+      title: Subscription
+      required:
+        - current_until
+        - current
+        - upcoming
+        - cancel_date
+      properties:
+        current_until:
+          title: 'End of current subscription period'
+          type: string
+          format: date
+          example: '2024-01-31'
+        current:
+          title: 'Current subscription settings'
+          required:
+            - plan_id
+            - plan_name
+            - number_of_licences
+            - interval
+          properties:
+            plan_id:
+              title: 'ID of current plan type'
+              type: integer
+              example: 102
+            plan_name:
+              title: 'Name of current plan type'
+              type: string
+              example: Pro
+            number_of_licences:
+              title: 'Number of currently booked licences'
+              type:
+                - integer
+                - 'null'
+              example: 5
+            interval:
+              title: 'Current payment interval'
+              type:
+                - string
+                - 'null'
+              example: monthly
+          type: object
+        upcoming:
+          title: 'Upcoming subscription settings'
+          required:
+            - plan_id
+            - plan_name
+            - number_of_licences
+            - interval
+          properties:
+            plan_id:
+              title: 'ID of upcoming plan type'
+              type: integer
+              example: 102
+            plan_name:
+              title: 'Name of upcoming plan type'
+              type: string
+              example: Pro
+            number_of_licences:
+              title: 'Number of upcoming booked licences'
+              type: integer
+              example: 5
+            interval:
+              title: 'Upcoming payment interval'
+              type: string
+              example: monthly
+          type:
+            - object
+            - 'null'
+        cancel_date:
+          title: 'Date of cancellation'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2024-01-31'
+      type: object
+    TargetHourType:
+      title: 'Target hour type'
+      description: "Possible values:\n- `weekly`: Weekly\n- `monthly`: Monthly"
+      type: string
+      enum:
+        - weekly
+        - monthly
+      x-enumNames:
+        - Weekly
+        - Monthly
+    TargetHourV1:
+      oneOf:
+        -
+          $ref: '#/components/schemas/TargetHourV1Weekly'
+        -
+          $ref: '#/components/schemas/TargetHourV1Monthly'
+    TargetHourV1Monthly:
+      required:
+        - id
+        - users_id
+        - type
+        - surcharge_models_id
+        - date_since
+        - date_until
+        - test_data
+        - workday_monday
+        - workday_tuesday
+        - workday_wednesday
+        - workday_thursday
+        - workday_friday
+        - workday_saturday
+        - workday_sunday
+        - monthly_target
+        - compensation_monthly
+      properties:
+        id:
+          description: 'The ID of the target hour settings'
+          type: integer
+          format: int64
+          example: 10
+        users_id:
+          description: "The related employee's ID"
+          type: integer
+          format: int64
+          example: 10
+        surcharge_models_id:
+          description: 'The corresponding surcharge model'
+          type:
+            - integer
+            - 'null'
+          format: int64
+          example: 10
+        type:
+          description: 'Type of the target hours row'
+          type: string
+          enum:
+            - monthly
+          example: monthly
+        date_since:
+          description: 'Date from which on the target hours apply (Format YYYY-MM-DD)'
+          type: string
+          format: date
+          example: '2023-02-28'
+        date_until:
+          description: 'Date until which the target hours apply (Format YYYY-MM-DD)'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2023-03-03'
+        test_data:
+          description: 'Defines if the Targethoursrow was generated as test data'
+          type: boolean
+        workday_monday:
+          description: 'Is Monday a work day?'
+          type: boolean
+          example: true
+        workday_tuesday:
+          description: 'Is Tuesday a work day?'
+          type: boolean
+          example: true
+        workday_wednesday:
+          description: 'Is Wednesday a work day?'
+          type: boolean
+          example: true
+        workday_thursday:
+          description: 'Is Thursday a work day?'
+          type: boolean
+          example: true
+        workday_friday:
+          description: 'Is Friday a work day?'
+          type: boolean
+          example: true
+        workday_saturday:
+          description: 'Is Saturday a work day?'
+          type: boolean
+          example: true
+        workday_sunday:
+          description: 'Is Sunday a work day?'
+          type: boolean
+          example: true
+        monthly_target:
+          description: 'Monthly target hours to attain'
+          type: number
+          example: 172.5
+        compensation_monthly:
+          description: 'Automatic time compensation per month in hours'
+          type: number
+          example: 0.5
+      type: object
+    TargetHourV1Weekly:
+      required:
+        - id
+        - users_id
+        - type
+        - surcharge_models_id
+        - date_since
+        - date_until
+        - test_data
+        - monday
+        - tuesday
+        - wednesday
+        - thursday
+        - friday
+        - saturday
+        - sunday
+        - compensation_daily
+        - compensation_monthly
+      properties:
+        id:
+          description: 'The ID of the target hour settings'
+          type: integer
+          format: int64
+          example: 10
+        users_id:
+          description: "The related employee's ID"
+          type: integer
+          format: int64
+          example: 10
+        surcharge_models_id:
+          description: 'The corresponding surcharge model'
+          type:
+            - integer
+            - 'null'
+          format: int64
+          example: 10
+        type:
+          description: 'Type of the target hours row'
+          type: string
+          enum:
+            - weekly
+          example: weekly
+        date_since:
+          description: 'Date from which on the target hours apply (Format YYYY-MM-DD)'
+          type: string
+          format: date
+          example: '2023-02-28'
+        date_until:
+          description: 'Date until which the target hours apply (Format YYYY-MM-DD)'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2023-03-03'
+        test_data:
+          description: 'Defines if the Targethoursrow was generated as test data'
+          type: boolean
+        monday:
+          description: 'Target hours for Monday'
+          type: number
+          example: 8.5
+        tuesday:
+          description: 'Target hours for Tuesday'
+          type: number
+          example: 8.5
+        wednesday:
+          description: 'Target hours for Wednesday'
+          type: number
+          example: 8.5
+        thursday:
+          description: 'Target hours for Thursday'
+          type: number
+          example: 8.5
+        friday:
+          description: 'Target hours for Friday'
+          type: number
+          example: 8.5
+        saturday:
+          description: 'Target hours for Saturday'
+          type: number
+          example: 8.5
+        sunday:
+          description: 'Target hours for Sunday'
+          type: number
+          example: 8.5
+        absence_fixed_credit:
+          description: 'true if credited absence hours are applied against the average target hours, false if credited absence hours match the target hours of the specific day'
+          type: boolean
+          example: true
+        compensation_daily:
+          description: 'Automatic time compensation per day in minutes'
+          type: number
+          example: 30.5
+        compensation_monthly:
+          description: 'Automatic time compensation per month in hours'
+          type: number
+          example: 0.5
+      type: object
+    TeamV3:
+      required:
+        - id
+        - name
+        - leader
+        - user_ids
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        leader:
+          title: 'The user ID of the team leader'
+          type:
+            - integer
+            - 'null'
+          format: int64
+        user_ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+      type: object
+    BlockingAccessDependencies:
+      title: 'There are blocking access dependencies that need to be removed beforehand'
+      required:
+        - access_name
+      properties:
+        access_name:
+          description: 'The access you were trying to remove'
+          type: string
+          example: see_absences
+        elevated_access_dependencies:
+          description: 'Elevated access dependencies that are blocking'
+          type: array
+          items:
+            type: string
+          example:
+            - see_work_time
+            - manage_work_time
+      type: object
+    Thresholds:
+      title: Thresholds
+      description: "Possible values:\n- `10`: Percent10\n- `20`: Percent20\n- `30`: Percent30\n- `40`: Percent40\n- `50`: Percent50\n- `60`: Percent60\n- `70`: Percent70\n- `80`: Percent80\n- `90`: Percent90\n- `100`: Percent100\n- `110`: Percent110\n- `120`: Percent120\n- `130`: Percent130\n- `140`: Percent140\n- `150`: Percent150\n- `200`: Percent200\n- `250`: Percent250\n- `300`: Percent300"
+      type: integer
+      enum:
+        - 10
+        - 20
+        - 30
+        - 40
+        - 50
+        - 60
+        - 70
+        - 80
+        - 90
+        - 100
+        - 110
+        - 120
+        - 130
+        - 140
+        - 150
+        - 200
+        - 250
+        - 300
+      x-enumNames:
+        - Percent10
+        - Percent20
+        - Percent30
+        - Percent40
+        - Percent50
+        - Percent60
+        - Percent70
+        - Percent80
+        - Percent90
+        - Percent100
+        - Percent110
+        - Percent120
+        - Percent130
+        - Percent140
+        - Percent150
+        - Percent200
+        - Percent250
+        - Percent300
+    EntryV2Time:
+      title: 'Time Entry'
+      required:
+        - id
+        - customers_id
+        - projects_id
+        - subprojects_id
+        - users_id
+        - billable
+        - texts_id
+        - text
+        - time_since
+        - time_until
+        - time_insert
+        - time_last_change
+        - test_data
+        - type
+        - services_id
+        - duration
+        - time_last_change_work_time
+        - time_clocked_since
+        - clocked
+        - clocked_offline
+      properties:
+        id:
+          title: ID
+          type: integer
+          format: int64
+          example: 10
+        customers_id:
+          title: "Customer's ID"
+          type: integer
+          format: int64
+          example: 10
+        projects_id:
+          title: "Project's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        subprojects_id:
+          title: "Subproject's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        users_id:
+          title: "User's ID"
+          type: integer
+          format: int64
+        billable:
+          title: 'is it billable?'
+          type: integer
+          format: int64
+        texts_id:
+          title: "Entry text's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        text:
+          title: Description
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+        time_since:
+          title: 'Start date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        time_until:
+          title: 'End date and time'
+          type:
+            - string
+            - 'null'
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        time_insert:
+          title: 'Insertion date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28Z00:00:00Z'
+        time_last_change:
+          title: 'Modification date and time'
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        test_data:
+          title: 'is a test dataset?'
+          type: boolean
+        customers_name:
+          title: "Customer's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'Hotel Bergblick'
+        projects_name:
+          title: "Project's name"
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+          example: 'Publicity campaign'
+        subprojects_name:
+          title: "Subproject's name"
+          description: 'Only if enhanced_list=true'
+          type:
+            - string
+            - 'null'
+          example: 'Social media ads'
+        users_name:
+          title: "User's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'Max Mustermann'
+        revenue:
+          title: Revenue
+          description: 'Only with necessary access rights and if enhanced_list=true'
+          type: number
+          example: 999.9
+        type:
+          title: Revenue
+          description: 'Entry type: 1 = time, 2 = lump sum value, 3 = lump sum service.'
+          type: number
+          enum:
+            - 1
+        services_id:
+          title: "Service's ID"
+          type:
+            - integer
+            - 'null'
+          format: int64
+        duration:
+          title: 'Duration in seconds'
+          type:
+            - integer
+            - 'null'
+          format: int64
+        time_last_change_work_time:
+          type: string
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        time_clocked_since:
+          type:
+            - string
+            - 'null'
+          format: date-time
+          example: '2023-02-28T00:00:00Z'
+        clocked:
+          type: boolean
+        clocked_offline:
+          type: boolean
+        hourly_rate:
+          description: 'Only with necessary access rights and if enhanced_list=true'
+          type: number
+          example: 99.99
+        services_name:
+          title: "Service's name"
+          description: 'Only if enhanced_list=true'
+          type: string
+          example: 'SEO service'
+      type: object
+    UnexpectedValueError:
+      title: 'Unexpected value error'
+      properties:
+        type:
+          type: string
+          enum:
+            - UnexpectedValue
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Only these values are expected: string'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/ExpectedValues'
+      type: object
+      x-error-category: BadRequest
+    UntilBeforeSinceIsForbiddenError:
+      title: 'Until before since is forbidden error'
+      properties:
+        type:
+          type: string
+          enum:
+            - UntilBeforeSinceIsForbidden
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Until date must be after or equal to the since date.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    UntilMustBeInSameYearError:
+      title: 'Until must be in same year error'
+      properties:
+        type:
+          type: string
+          enum:
+            - UntilMustBeInSameYear
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'The "until" date must be in the same year as the "since" date.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    UserV3:
+      title: User
+      required:
+        - id
+        - name
+        - weekstart_monday
+        - weekend_friday
+        - active
+        - timeformat_12h
+        - language
+        - timezone
+        - teams_id
+        - initials
+        - nonbusiness_groups_id
+      properties:
+        id:
+          title: ID
+          type: integer
+          format: int64
+          example: 10
+        name:
+          title: Name
+          type: string
+          maxLength: 100
+        weekstart_monday:
+          title: 'Start week on Monday?'
+          description: 'If false, the week starts on Sunday'
+          type: boolean
+        weekend_friday:
+          title: 'Is the weekend Friday and Saturday?'
+          description: 'This property no longer has any effect'
+          type: boolean
+          deprecated: true
+        active:
+          title: Active
+          type: boolean
+        timeformat_12h:
+          title: 'Use 12h time format?'
+          type: boolean
+        language:
+          title: Language
+          enum:
+            - en
+            - fr
+            - de
+        timezone:
+          title: 'Time zone'
+          description: 'e.g. `Europe/Berlin`'
+          type: string
+        teams_id:
+          title: 'ID of the team'
+          type:
+            - integer
+            - 'null'
+          format: int64
+        initials:
+          title: Initials
+          type: string
+        nonbusiness_groups_id:
+          title: 'ID of the nonbusiness group'
+          description: 'deprecated; use v2/usersNonbusinessGroups instead'
+          type:
+            - integer
+            - 'null'
+          format: int64
+          deprecated: true
+        nonbusinessgroups_id:
+          title: 'ID of the nonbusiness group'
+          description: 'deprecated; use nonbusiness_groups_id instead'
+          type: integer
+          format: int64
+          deprecated: true
+        number:
+          title: Number
+          type:
+            - string
+            - 'null'
+          maxLength: 50
+        work_time_regulations_id:
+          title: 'ID of the work time regulation'
+          description: '`0` if the co-worker has no work time regulation\n`null` if the company default is applicable'
+          type:
+            - integer
+            - 'null'
+          format: int64
+        default_work_time_regulation:
+          title: 'Default work time regulation'
+          description: "Uses the company's default work time regulation"
+          type: boolean
+        worktime_regulation_id:
+          title: 'ID of the work time regulation'
+          description: 'deprecated; use work_time_regulations_id instead'
+          type:
+            - integer
+            - 'null'
+          format: int64
+          deprecated: true
+        boss:
+          title: 'ID of the boss'
+          type:
+            - integer
+            - 'null'
+          format: int64
+        absence_managers_id:
+          title: 'Absence managers IDs'
+          type: array
+          items:
+            type: integer
+            format: int64
+        access_groups_ids:
+          title: 'Access groups IDs'
+          type: array
+          items:
+            type: integer
+            format: int64
+        email:
+          title: 'Email address'
+          type: string
+          maxLength: 90
+        role:
+          $ref: '#/components/schemas/Role'
+        can_generally_see_absences:
+          title: "Can see other co-workers' absences?"
+          description: "Only editable for co-workers with the role 'worker'"
+          type: boolean
+        can_generally_manage_absences:
+          title: "Can edit other co-workers' absences?"
+          description: "Only editable for co-workers with the role 'worker'"
+          type: boolean
+        can_add_customers:
+          title: 'Can add customers'
+          description: "Only editable for co-workers with the role 'worker'"
+          type: boolean
+        default_holidays_count:
+          description: "Uses the company's default holiday count"
+          type: boolean
+        default_target_hours:
+          title: 'Default target hours'
+          description: "Uses the company's default target hours"
+          type: boolean
+        future_coworker:
+          title: 'Is future co-worker?'
+          description: 'The future co-worker cannot log in yet and the license is free until the start date.'
+          type: boolean
+          example: true
+        start_date:
+          title: 'Start date'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2024-07-15'
+        exit_date:
+          title: 'Exit date'
+          description: 'The co-worker is automatically archived when this date is reached. Use the `put` action to set or update this value.'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2026-12-31'
+          x-feature-flag: exit_date
+        wage_type:
+          oneOf:
+            -
+              $ref: '#/components/schemas/WageType'
+            -
+              type: 'null'
+          title: 'Relevant for DATEV export'
+        edit_lock:
+          title: 'Edit lock'
+          description: 'Defined editing lock for the co-worker'
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2024-06-15'
+        edit_lock_dyn:
+          oneOf:
+            -
+              $ref: '#/components/schemas/EditLockDay'
+              description: 'Relative editing lock in days for the co-worker'
+            -
+              type: 'null'
+          title: 'Dynamic edit lock'
+          description: 'Relative editing lock in days for the co-worker'
+        edit_lock_sync:
+          title: 'Can changes to the company-wide edit lock overwrite the edit lock for this co-worker?'
+          type:
+            - boolean
+            - 'null'
+        work_time_edit_lock_days:
+          oneOf:
+            -
+              $ref: '#/components/schemas/WorkTimeEditLockDay'
+              description: 'Relative work time editing lock in days for the co-worker'
+            -
+              type: 'null'
+          title: 'Work time edit lock days'
+          description: 'Relative work time editing lock in days for the co-worker'
+        budget_notifications:
+          type: boolean
+        creator:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        created_at:
+          type: string
+          format: date-time
+          example: '2024-07-15T10:00:00Z'
+        bill_service_id:
+          description: 'Only visible for administrators or workers with elevated access `manage_add_ons` and `manage_users_and_teams` and if a billing application with user support is linked up'
+          type:
+            - string
+            - 'null'
+          example: '1234'
+        support_pin:
+          type: string
+          example: '1234'
+        exempt_from_flextime:
+          description: 'Is exempt from flextime violation evaluation'
+          type: boolean
+      type: object
+    UserCannotDeleteThemselvesError:
+      title: 'User cannot delete themselves error'
+      properties:
+        type:
+          type: string
+          enum:
+            - UserCannotDeleteThemselves
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'User cannot delete themselves.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: Forbidden
+    UserHasAnotherTeamError:
+      title: 'User has another team error'
+      properties:
+        type:
+          type: string
+          enum:
+            - UserHasAnotherTeam
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'User already has another team.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/UserHasAnotherTeam'
+      type: object
+      x-error-category: BadRequest
+    UserHasAnotherTeam:
+      title: 'User has another team error details'
+      required:
+        - users_in_another_team
+      properties:
+        users_in_another_team:
+          title: 'Users in another team'
+          type: array
+          items:
+            type: integer
+          example:
+            - 99999
+      type: object
+    UserReportAbsenceSummaryV1:
+      required:
+        - regular_holidays
+        - sick_self
+        - sick_child
+        - special_leaves
+        - school
+        - maternity_protection
+        - home_office
+        - out_of_office
+        - quarantine
+        - military_service
+      properties:
+        regular_holidays:
+          type: number
+          format: float
+        sick_self:
+          type: number
+          format: float
+        sick_child:
+          type: number
+          format: float
+        special_leaves:
+          type: number
+          format: float
+        school:
+          type: number
+          format: float
+        maternity_protection:
+          type: number
+          format: float
+        home_office:
+          type: number
+          format: float
+        out_of_office:
+          type: number
+          format: float
+        quarantine:
+          type: number
+          format: float
+        military_service:
+          type: number
+          format: float
+      type: object
+    UserReportBreakItemV1:
+      required:
+        - since
+        - until
+        - length
+      properties:
+        since:
+          type: string
+          format: date-time
+        until:
+          type: string
+          format: date-time
+        length:
+          type: number
+          format: float
+      type: object
+    UserReportDayDetailV1:
+      required:
+        - date
+        - weekday
+        - nonbusiness
+        - count_absence
+        - count_reduction_used
+        - target
+        - target_raw
+        - surcharges
+      properties:
+        date:
+          type: string
+          format: date
+        weekday:
+          type: integer
+        nonbusiness:
+          type: boolean
+        count_absence:
+          $ref: '#/components/schemas/UserReportAbsenceSummaryV1'
+        count_reduction_used:
+          type:
+            - number
+            - 'null'
+          format: float
+        target:
+          type:
+            - number
+            - 'null'
+          format: float
+        target_raw:
+          type:
+            - number
+            - 'null'
+          format: float
+        surcharges:
+          $ref: '#/components/schemas/UserReportSurchargeSummaryV1'
+        hours:
+          type:
+            - number
+            - 'null'
+          format: float
+        hours_without_compensation:
+          type:
+            - number
+            - 'null'
+          format: float
+        diff:
+          type: number
+          format: float
+        breaks:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserReportBreakItemV1'
+        work_start:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        work_end:
+          type:
+            - string
+            - 'null'
+          format: date-time
+      type: object
+    UserReportMonthDetailV1:
+      required:
+        - nr
+        - sum_target
+        - sum_hours
+        - sum_hours_without_compensation
+        - sum_reduction_used
+        - sum_overtime_reduced
+        - diff
+        - surcharges
+        - week_details
+      properties:
+        nr:
+          type: integer
+        sum_target:
+          type:
+            - number
+            - 'null'
+          format: float
+        sum_hours:
+          type: number
+          format: float
+        sum_hours_without_compensation:
+          type: number
+          format: float
+        sum_reduction_used:
+          type: number
+          format: float
+        sum_overtime_reduced:
+          type: number
+          format: float
+        diff:
+          type: number
+          format: float
+        surcharges:
+          $ref: '#/components/schemas/UserReportSurchargeSummaryV1'
+        week_details:
+          type:
+            - array
+            - 'null'
+          items:
+            $ref: '#/components/schemas/UserReportWeekDetailV1'
+      type: object
+    UserReportSurchargeSummaryV1:
+      required:
+        - saturday
+        - sunday
+        - nonbusiness
+        - nonbusiness_special
+        - night
+        - night_increased
+      properties:
+        saturday:
+          type: number
+          format: float
+        sunday:
+          type: number
+          format: float
+        nonbusiness:
+          type: number
+          format: float
+        nonbusiness_special:
+          type: number
+          format: float
+        night:
+          type: number
+          format: float
+        night_increased:
+          type: number
+          format: float
+      type: object
+    UserReportType:
+      title: 'User report type'
+      description: "Possible values:\n- `0`: Year\n- `1`: Month\n- `2`: Week\n- `3`: Day\n- `4`: DayWithWorkTime"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+      x-enumNames:
+        - Year
+        - Month
+        - Week
+        - Day
+        - DayWithWorkTime
+    UserReportV1:
+      required:
+        - users_id
+        - users_name
+        - users_number
+        - users_email
+        - sum_target
+        - sum_hours
+        - sum_reduction_used
+        - sum_reduction_planned
+        - overtime_carryover
+        - overtime_reduced
+        - diff
+        - holidays_quota
+        - holidays_carry
+        - sum_absence
+        - surcharges
+        - workdays
+        - month_details
+      properties:
+        users_id:
+          type: integer
+        users_name:
+          type: string
+        users_number:
+          title: 'Personnel number'
+          type:
+            - string
+            - 'null'
+        users_email:
+          type: string
+        sum_target:
+          title: 'Planned work time for the year'
+          description: 'In seconds'
+          type:
+            - number
+            - 'null'
+          format: float
+        sum_hours:
+          title: 'Work time in the year'
+          description: 'In seconds'
+          type: number
+          format: float
+        sum_reduction_used:
+          title: 'Sum of overtime reductions in the year'
+          description: 'In seconds'
+          type: number
+          format: float
+        sum_reduction_planned:
+          title: 'Sum of planned overtime reductions in the rest of the year'
+          description: 'In seconds'
+          type: number
+          format: float
+        overtime_carryover:
+          title: 'Overtime carryover for the year'
+          description: 'In seconds'
+          type: number
+          format: float
+        overtime_reduced:
+          title: 'Overtime reduced for the year'
+          description: 'In seconds'
+          type: number
+          format: float
+        diff:
+          title: 'Calculated difference of the work time of the year'
+          description: 'In seconds'
+          type: number
+          format: float
+        holidays_quota:
+          title: 'Vacation quota for the year'
+          type: number
+          format: float
+        holidays_carry:
+          title: 'Vacation carryover for the year'
+          type: number
+          format: float
+        sum_absence:
+          $ref: '#/components/schemas/UserReportAbsenceSummaryV1'
+        surcharges:
+          $ref: '#/components/schemas/UserReportSurchargeSummaryV1'
+        workdays:
+          type: number
+          format: float
+        month_details:
+          type:
+            - array
+            - 'null'
+          items:
+            $ref: '#/components/schemas/UserReportMonthDetailV1'
+      type: object
+    UserReportWeekDetailV1:
+      required:
+        - nr
+        - sum_target
+        - sum_hours
+        - sum_reduction_used
+        - diff
+        - surcharges
+        - day_details
+      properties:
+        nr:
+          type: integer
+        sum_target:
+          type:
+            - number
+            - 'null'
+          format: float
+        sum_hours:
+          type: number
+          format: float
+        sum_reduction_used:
+          type: number
+          format: float
+        diff:
+          type: number
+          format: float
+        surcharges:
+          $ref: '#/components/schemas/UserReportSurchargeSummaryV1'
+        day_details:
+          type:
+            - array
+            - 'null'
+          items:
+            $ref: '#/components/schemas/UserReportDayDetailV1'
+      type: object
+    UsersAccessCustomersProjectCustomerChildRestrictedAccessV2:
+      required:
+        - projects
+      properties:
+        projects:
+          type: object
+          additionalProperties:
+            type: boolean
+      type: object
+    UsersAccessCustomersProjectV2:
+      required:
+        - add
+        - report
+        - edit
+      properties:
+        add:
+          oneOf:
+            -
+              type: boolean
+            -
+              type: object
+              additionalProperties:
+                oneOf:
+                  - { type: boolean }
+                  - { $ref: '#/components/schemas/UsersAccessCustomersProjectCustomerChildRestrictedAccessV2' }
+        report:
+          oneOf:
+            -
+              type: boolean
+            -
+              type: object
+              additionalProperties:
+                oneOf:
+                  - { type: boolean }
+                  - { $ref: '#/components/schemas/UsersAccessCustomersProjectCustomerChildRestrictedAccessV2' }
+        edit:
+          oneOf:
+            -
+              type: boolean
+            -
+              type: object
+              additionalProperties:
+                oneOf:
+                  - { type: boolean }
+                  - { $ref: '#/components/schemas/UsersAccessCustomersProjectCustomerChildRestrictedAccessV2' }
+      type: object
+    UsersAccessServiceV2:
+      required:
+        - add
+      properties:
+        add:
+          oneOf:
+            -
+              type: boolean
+            -
+              type: object
+              additionalProperties:
+                type: boolean
+      type: object
+    UserScope:
+      title: 'User scope'
+      description: "Possible values:\n- `manageAbsences`: ManageAbsences\n- `viewAbsences`: ViewAbsences\n- `viewUserReports`: ViewUserReports\n- `viewUserReportsDetailed`: ViewUserReportsDetailed\n- `viewPresences`: ViewPresences"
+      type: string
+      enum:
+        - manageAbsences
+        - viewAbsences
+        - viewUserReports
+        - viewUserReportsDetailed
+        - viewPresences
+      x-enumNames:
+        - ManageAbsences
+        - ViewAbsences
+        - ViewUserReports
+        - ViewUserReportsDetailed
+        - ViewPresences
+    UsersExceedAccessGroupLimitError:
+      title: 'Users exceed access group limit error'
+      properties:
+        type:
+          type: string
+          enum:
+            - UsersExceedAccessGroupLimit
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'Users are exceeding the access group limit.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          $ref: '#/components/schemas/UsersExceedAccessGroupLimit'
+      type: object
+      x-error-category: Forbidden
+    UsersExceedAccessGroupLimit:
+      title: 'Users exceeding access group limit error details'
+      required:
+        - limit
+        - users_ids
+      properties:
+        limit:
+          description: 'The limit of access groups per user'
+          type: integer
+          format: int64
+          example: 30
+        users_ids:
+          description: 'One or more ids of users exceeding the access group limit'
+          type: array
+          items:
+            type: integer
+          example:
+            - 99999
+      type: object
+    UsersNonbusinessDayV2:
+      required:
+        - users_id
+        - days
+      properties:
+        users_id:
+          type: integer
+          format: int64
+          example: 10
+        days:
+          description: 'Nonbusiness days that apply for the user in the queried time span'
+          type: array
+          items:
+            $ref: '#/components/schemas/NonbusinessDayV2'
+      type: object
+    UsersNonbusinessGroupsCollisionError:
+      title: 'Users nonbusiness groups collision error'
+      properties:
+        type:
+          type: string
+          enum:
+            - UsersNonbusinessGroupsCollision
+        message:
+          type:
+            - string
+            - 'null'
+          example: 'An error occurred, please try again.'
+        path:
+          type:
+            - string
+            - 'null'
+        details:
+          type: 'null'
+      type: object
+      x-error-category: BadRequest
+    UsersNonbusinessGroupV3:
+      required:
+        - id
+        - date_since
+        - date_until
+        - nonbusiness_groups_id
+        - users_id
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        date_since:
+          type: string
+          format: date
+          example: '2025-01-31'
+        date_until:
+          type:
+            - string
+            - 'null'
+          format: date
+          example: '2025-01-31'
+        nonbusiness_groups_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+          example: 10
+        users_id:
+          type: integer
+          format: int64
+          example: 10
+      type: object
+    UserV1:
+      required:
+        - id
+        - name
+        - weekstart_monday
+        - weekend_friday
+        - active
+        - timeformat_12h
+        - language
+        - timezone
+        - teams_id
+        - initials
+        - nonbusinessgroups_id
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type:
+            - string
+            - 'null'
+        number:
+          type:
+            - string
+            - 'null'
+        email:
+          type: string
+        role:
+          $ref: '#/components/schemas/Role'
+        active:
+          type: boolean
+        timeformat_12h:
+          type: boolean
+        weekstart_monday:
+          type:
+            - boolean
+            - 'null'
+        weekend_friday:
+          type:
+            - boolean
+            - 'null'
+        language:
+          $ref: '#/components/schemas/Language'
+        timezone:
+          type: string
+        wage_type:
+          oneOf:
+            -
+              $ref: '#/components/schemas/WageType'
+            -
+              type: 'null'
+        can_generally_see_absences:
+          type: boolean
+        can_generally_manage_absences:
+          type: boolean
+        can_add_customers:
+          type: boolean
+        worktime_regulation_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        teams_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        initials:
+          type:
+            - string
+            - 'null'
+        nonbusinessgroups_id:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        boss:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        absence_managers_id:
+          type: array
+          items:
+            type: integer
+            format: int64
+        default_holidays_count:
+          type: boolean
+        default_target_hours:
+          type: boolean
+        edit_lock:
+          type:
+            - string
+            - 'null'
+        edit_lock_dyn:
+          oneOf:
+            -
+              $ref: '#/components/schemas/EditLockDay'
+            -
+              type: 'null'
+        edit_lock_sync:
+          type:
+            - boolean
+            - 'null'
+        work_time_edit_lock_days:
+          oneOf:
+            -
+              $ref: '#/components/schemas/WorkTimeEditLockDay'
+            -
+              type: 'null'
+        creator:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        support_pin:
+          type: string
+      type: object
+    WageType:
+      title: 'Wage type'
+      description: "Possible values:\n- `1`: Salary\n- `2`: HourlyWage"
+      type: integer
+      enum:
+        - 1
+        - 2
+      x-enumNames:
+        - Salary
+        - HourlyWage
+    WebhookEvent_absence_approved:
+      title: 'Webhook Event: absence.approved'
+      description: 'Complete webhook body for event "absence.approved"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            absence:
+              description: 'The absence entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the absence'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: absence.approved
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_absence_created:
+      title: 'Webhook Event: absence.created'
+      description: 'Complete webhook body for event "absence.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            absence:
+              description: 'The absence entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the absence'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: absence.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_absence_deleted:
+      title: 'Webhook Event: absence.deleted'
+      description: 'Complete webhook body for event "absence.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            absence:
+              description: 'The absence entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the absence'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: absence.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_absence_updated:
+      title: 'Webhook Event: absence.updated'
+      description: 'Complete webhook body for event "absence.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            absence:
+              description: 'The absence entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the absence'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: absence.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_customer_created:
+      title: 'Webhook Event: customer.created'
+      description: 'Complete webhook body for event "customer.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            customer:
+              description: 'The customer entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the customer'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: customer.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_customer_deleted:
+      title: 'Webhook Event: customer.deleted'
+      description: 'Complete webhook body for event "customer.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            customer:
+              description: 'The customer entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the customer'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: customer.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_customer_updated:
+      title: 'Webhook Event: customer.updated'
+      description: 'Complete webhook body for event "customer.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            customer:
+              description: 'The customer entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the customer'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: customer.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_entry_created:
+      title: 'Webhook Event: entry.created'
+      description: 'Complete webhook body for event "entry.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            entry:
+              description: 'The entry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the entry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: entry.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_entry_deleted:
+      title: 'Webhook Event: entry.deleted'
+      description: 'Complete webhook body for event "entry.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            entry:
+              description: 'The entry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the entry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: entry.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_entry_started:
+      title: 'Webhook Event: entry.started'
+      description: 'Complete webhook body for event "entry.started"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            entry:
+              description: 'The entry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the entry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: entry.started
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_entry_stopped:
+      title: 'Webhook Event: entry.stopped'
+      description: 'Complete webhook body for event "entry.stopped"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            entry:
+              description: 'The entry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the entry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: entry.stopped
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_entry_updated:
+      title: 'Webhook Event: entry.updated'
+      description: 'Complete webhook body for event "entry.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            entry:
+              description: 'The entry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the entry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: entry.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_holidays_carry_created:
+      title: 'Webhook Event: holidays_carry.created'
+      description: 'Complete webhook body for event "holidays_carry.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            holidays_carry:
+              description: 'The holidays carry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the holidays carry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: holidays_carry.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_holidays_carry_deleted:
+      title: 'Webhook Event: holidays_carry.deleted'
+      description: 'Complete webhook body for event "holidays_carry.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            holidays_carry:
+              description: 'The holidays carry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the holidays carry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: holidays_carry.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_holidays_carry_updated:
+      title: 'Webhook Event: holidays_carry.updated'
+      description: 'Complete webhook body for event "holidays_carry.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            holidays_carry:
+              description: 'The holidays carry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the holidays carry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: holidays_carry.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_holidays_quota_created:
+      title: 'Webhook Event: holidays_quota.created'
+      description: 'Complete webhook body for event "holidays_quota.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            holidays_quota:
+              description: 'The holidays quota entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the holidays quota'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: holidays_quota.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_holidays_quota_deleted:
+      title: 'Webhook Event: holidays_quota.deleted'
+      description: 'Complete webhook body for event "holidays_quota.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            holidays_quota:
+              description: 'The holidays quota entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the holidays quota'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: holidays_quota.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_holidays_quota_updated:
+      title: 'Webhook Event: holidays_quota.updated'
+      description: 'Complete webhook body for event "holidays_quota.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            holidays_quota:
+              description: 'The holidays quota entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the holidays quota'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: holidays_quota.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_lump_sum_service_created:
+      title: 'Webhook Event: lump_sum_service.created'
+      description: 'Complete webhook body for event "lump_sum_service.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            lump_sum_service:
+              description: 'The lump sum service entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the lump sum service'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: lump_sum_service.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_lump_sum_service_deleted:
+      title: 'Webhook Event: lump_sum_service.deleted'
+      description: 'Complete webhook body for event "lump_sum_service.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            lump_sum_service:
+              description: 'The lump sum service entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the lump sum service'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: lump_sum_service.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_lump_sum_service_updated:
+      title: 'Webhook Event: lump_sum_service.updated'
+      description: 'Complete webhook body for event "lump_sum_service.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            lump_sum_service:
+              description: 'The lump sum service entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the lump sum service'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: lump_sum_service.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_nonbusiness_group_created:
+      title: 'Webhook Event: nonbusiness_group.created'
+      description: 'Complete webhook body for event "nonbusiness_group.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            nonbusiness_group:
+              description: 'The nonbusiness group entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the nonbusiness group'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: nonbusiness_group.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_nonbusiness_group_deleted:
+      title: 'Webhook Event: nonbusiness_group.deleted'
+      description: 'Complete webhook body for event "nonbusiness_group.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            nonbusiness_group:
+              description: 'The nonbusiness group entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the nonbusiness group'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: nonbusiness_group.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_nonbusiness_group_updated:
+      title: 'Webhook Event: nonbusiness_group.updated'
+      description: 'Complete webhook body for event "nonbusiness_group.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            nonbusiness_group:
+              description: 'The nonbusiness group entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the nonbusiness group'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: nonbusiness_group.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_overtime_carry_created:
+      title: 'Webhook Event: overtime_carry.created'
+      description: 'Complete webhook body for event "overtime_carry.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            overtime_carry:
+              description: 'The overtime carry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the overtime carry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: overtime_carry.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_overtime_carry_deleted:
+      title: 'Webhook Event: overtime_carry.deleted'
+      description: 'Complete webhook body for event "overtime_carry.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            overtime_carry:
+              description: 'The overtime carry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the overtime carry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: overtime_carry.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_overtime_carry_updated:
+      title: 'Webhook Event: overtime_carry.updated'
+      description: 'Complete webhook body for event "overtime_carry.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            overtime_carry:
+              description: 'The overtime carry entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the overtime carry'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: overtime_carry.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_project_budget_notification:
+      title: 'Webhook Event: project.budget_notification'
+      description: 'Complete webhook body for event "project.budget_notification"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+            - type
+            - threshold
+          properties:
+            id:
+              description: 'The ID of the project'
+              type: integer
+              example: 123
+            type:
+              description: 'The type of budget notification'
+              type: string
+              example: projectBudget
+            threshold:
+              description: 'The budget threshold percentage that was exceeded'
+              type: integer
+              example: 80
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: project.budget_notification
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_project_completed:
+      title: 'Webhook Event: project.completed'
+      description: 'Complete webhook body for event "project.completed"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            project:
+              description: 'The project entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the project'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: project.completed
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_project_created:
+      title: 'Webhook Event: project.created'
+      description: 'Complete webhook body for event "project.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            project:
+              description: 'The project entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the project'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: project.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_project_deleted:
+      title: 'Webhook Event: project.deleted'
+      description: 'Complete webhook body for event "project.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            project:
+              description: 'The project entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the project'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: project.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_project_updated:
+      title: 'Webhook Event: project.updated'
+      description: 'Complete webhook body for event "project.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            project:
+              description: 'The project entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the project'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: project.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_service_created:
+      title: 'Webhook Event: service.created'
+      description: 'Complete webhook body for event "service.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            service:
+              description: 'The service entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the service'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: service.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_service_deleted:
+      title: 'Webhook Event: service.deleted'
+      description: 'Complete webhook body for event "service.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            service:
+              description: 'The service entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the service'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: service.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_service_updated:
+      title: 'Webhook Event: service.updated'
+      description: 'Complete webhook body for event "service.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            service:
+              description: 'The service entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the service'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: service.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_subproject_created:
+      title: 'Webhook Event: subproject.created'
+      description: 'Complete webhook body for event "subproject.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            subproject:
+              description: 'The subproject entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the subproject'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: subproject.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_subproject_deleted:
+      title: 'Webhook Event: subproject.deleted'
+      description: 'Complete webhook body for event "subproject.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            subproject:
+              description: 'The subproject entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the subproject'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: subproject.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_subproject_updated:
+      title: 'Webhook Event: subproject.updated'
+      description: 'Complete webhook body for event "subproject.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            subproject:
+              description: 'The subproject entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the subproject'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: subproject.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_team_created:
+      title: 'Webhook Event: team.created'
+      description: 'Complete webhook body for event "team.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            team:
+              description: 'The team entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the team'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: team.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_team_deleted:
+      title: 'Webhook Event: team.deleted'
+      description: 'Complete webhook body for event "team.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            team:
+              description: 'The team entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the team'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: team.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_team_updated:
+      title: 'Webhook Event: team.updated'
+      description: 'Complete webhook body for event "team.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            team:
+              description: 'The team entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the team'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: team.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_user_created:
+      title: 'Webhook Event: user.created'
+      description: 'Complete webhook body for event "user.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            user:
+              description: 'The user entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the user'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: user.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_user_deleted:
+      title: 'Webhook Event: user.deleted'
+      description: 'Complete webhook body for event "user.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            user:
+              description: 'The user entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the user'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: user.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_user_updated:
+      title: 'Webhook Event: user.updated'
+      description: 'Complete webhook body for event "user.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            user:
+              description: 'The user entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the user'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: user.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_work_time_change_request_created:
+      title: 'Webhook Event: work_time_change_request.created'
+      description: 'Complete webhook body for event "work_time_change_request.created"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            work_time_change_request:
+              description: 'The work time change request entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the work time change request'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: work_time_change_request.created
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_work_time_change_request_deleted:
+      title: 'Webhook Event: work_time_change_request.deleted'
+      description: 'Complete webhook body for event "work_time_change_request.deleted"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            work_time_change_request:
+              description: 'The work time change request entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the work time change request'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: work_time_change_request.deleted
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WebhookEvent_work_time_change_request_updated:
+      title: 'Webhook Event: work_time_change_request.updated'
+      description: 'Complete webhook body for event "work_time_change_request.updated"'
+      required:
+        - subscription_id
+        - company_id
+        - occurred_at
+        - payload
+        - event_name
+        - token
+      properties:
+        subscription_id:
+          description: 'The ID of the webhook subscription'
+          type: integer
+          example: 42
+        company_id:
+          description: 'The ID of the company'
+          type: integer
+          example: 1337
+        occurred_at:
+          description: 'The timestamp when the event occurred (ISO 8601 format)'
+          type: string
+          format: date-time
+          example: '1986-05-10T17:02:00Z'
+        payload:
+          description: 'The event-specific payload data'
+          required:
+            - id
+          properties:
+            work_time_change_request:
+              description: 'The work time change request entity'
+              required:
+                - id
+              properties:
+                id:
+                  description: 'The ID of the work time change request'
+                  type: integer
+                  example: 1
+              type: object
+          type: object
+        event_name:
+          description: 'The name of the webhook event'
+          type: string
+          const: work_time_change_request.updated
+        token:
+          description: 'The webhook verification token'
+          type: string
+          example: My_Sup3r_T0k3n
+      type: object
+    WorkTimeEditLockDay:
+      title: 'Work time edit lock day'
+      description: "Possible values:\n- `0`: LockDays0\n- `1`: LockDays1\n- `2`: LockDays2\n- `3`: LockDays3\n- `5`: LockDays5\n- `8`: LockDays8\n- `15`: LockDays15\n- `31`: LockDays31\n- `46`: LockDays46\n- `91`: LockDays91"
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+        - 5
+        - 8
+        - 15
+        - 31
+        - 46
+        - 91
+      x-enumNames:
+        - LockDays0
+        - LockDays1
+        - LockDays2
+        - LockDays3
+        - LockDays5
+        - LockDays8
+        - LockDays15
+        - LockDays31
+        - LockDays46
+        - LockDays91
+    WorkTimeIntervalV2:
+      required:
+        - time_since
+        - time_until
+      properties:
+        time_since:
+          type: string
+          format: date-time
+        time_until:
+          type:
+            - string
+            - 'null'
+          format: date-time
+      type: object
+    WorkTimeRegulationV3:
+      required:
+        - id
+        - add_to_worktime
+        - daily_max
+        - weekly_max
+        - interval_max
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          description: 'Only visible for administrators or workers with elevated access `manage_users_work_time_settings`'
+          type: string
+          example: Germany
+        add_to_worktime:
+          type: boolean
+          example: false
+        daily_max:
+          type:
+            - number
+            - 'null'
+          format: float
+          example: 10
+        weekly_max:
+          type:
+            - number
+            - 'null'
+          format: float
+          example: 60
+        interval_max:
+          type:
+            - number
+            - 'null'
+          format: float
+          example: 6
+      type: object
+    WorkTimesChangeRequestChangeV2:
+      required:
+        - type
+        - time_since
+        - time_until
+      properties:
+        type:
+          $ref: '#/components/schemas/ChangeRequestIntervalType'
+        time_since:
+          type: string
+          format: date-time
+        time_until:
+          type: string
+          format: date-time
+      type: object
+    WorkTimesChangeRequestDeleteV2:
+      required:
+        - change_request
+      properties:
+        change_request:
+          type: 'null'
+      type: object
+    WorkTimesChangeRequestPostV2:
+      required:
+        - change_request
+        - replaced_change_request
+        - approved_immediately
+      properties:
+        change_request:
+          oneOf:
+            -
+              $ref: '#/components/schemas/WorkTimesChangeRequestV2'
+            -
+              type: 'null'
+        replaced_change_request:
+          oneOf:
+            -
+              $ref: '#/components/schemas/WorkTimesChangeRequestV2'
+            -
+              type: 'null'
+        approved_immediately:
+          type: boolean
+      type: object
+    WorkTimesChangeRequestsDeclineChangeV2:
+      required:
+        - type
+        - time_since
+        - time_until
+      properties:
+        type:
+          $ref: '#/components/schemas/ChangeRequestIntervalType'
+        time_since:
+          type: string
+        time_until:
+          type:
+            - string
+            - 'null'
+      type: object
+    WorkTimesChangeRequestsDeclineV2:
+      required:
+        - id
+        - date
+        - users_id
+        - status
+        - created_at
+        - declined_at
+        - declined_by
+        - changes
+      properties:
+        id:
+          type: integer
+          format: int64
+        date:
+          type: string
+        users_id:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/ChangeRequestStatus'
+        created_at:
+          type:
+            - string
+            - 'null'
+        declined_at:
+          type:
+            - string
+            - 'null'
+        declined_by:
+          type:
+            - integer
+            - 'null'
+          format: int64
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkTimesChangeRequestsDeclineChangeV2'
+      type: object
+    WorkTimesChangeRequestV2:
+      required:
+        - id
+        - date
+        - users_id
+        - status
+        - created_at
+        - declined_at
+        - declined_by
+        - changes
+      properties:
+        id:
+          type: integer
+          format: int64
+        date:
+          type: string
+          format: date
+        users_id:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/ChangeRequestStatus'
+        created_at:
+          type: string
+          format: date-time
+        declined_at:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        declined_by:
+          title: 'ID of the user who declined the change request'
+          type:
+            - integer
+            - 'null'
+          format: int64
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkTimesChangeRequestChangeV2'
+      type: object
+    WorkTimeV2:
+      required:
+        - date
+        - users_id
+        - offset
+        - intervals
+      properties:
+        date:
+          type: string
+          format: date
+        users_id:
+          type: integer
+          format: int64
+        offset:
+          title: "Additional work time that does not result form the day's intervals"
+          description: 'Only possible for days before 2023-01-01; can be positive or negative.'
+          type: integer
+          format: int64
+        intervals:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorkTimeIntervalV2'
+      type: object
+    MissingManageUsersAccessForAssigningAccessGroup:
+      title: "You're missing manage users access"
+      required:
+        - access_groups_ids
+      properties:
+        access_groups_ids:
+          description: 'The access groups with elevated access'
+          type: array
+          items:
+            type: integer
+            format: int64
+      type: object
+    MissingManageUsersAccessForRemovingAccessGroup:
+      title: "You're missing manage users access"
+      required:
+        - access_groups_ids
+      properties:
+        access_groups_ids:
+          description: 'The access groups with elevated access'
+          type: array
+          items:
+            type: integer
+            format: int64
+      type: object
+  securitySchemes:
+    BasicAuth:
+      type: http
+      description: 'The basic authentication of the HTTP protocol. Credentials are email address and API key.<br />Every co-worker will find his API key in the menu item "Personal data" in his Clockodo account.'
+      scheme: basic
+    User:
+      type: apiKey
+      description: 'Must be filled together with <code>X-ClockodoApiKey</code><br /><strong>Example: admin@clockodo.com</strong>'
+      name: X-ClockodoApiUser
+      in: header
+    Key:
+      type: apiKey
+      description: 'Must be filled together with <code>X-ClockodoApiUser</code>'
+      name: X-ClockodoApiKey
+      in: header
+    ExternalApp:
+      type: apiKey
+      description: 'Every request to our API must provide identification of the calling application, including the email address of a technical contact person.<br /><strong>Example: "Clockodo;admin@clockodo.com"</strong>'
+      name: X-Clockodo-External-Application
+      in: header
+security:
+  -
+    BasicAuth: []
+    ExternalApp: []
+  -
+    User: []
+    Key: []
+    ExternalApp: []
+tags:
+  -
+    name: Absence
+    description: 'Manage absences (holidays, sick days, etc.)'
+  -
+    name: AccessGroup
+    description: 'Manage access groups names and assigned users'
+  -
+    name: AccessGroupAccess
+    description: 'Manage access group rights'
+  -
+    name: AggregatesUsersMe
+    description: 'Get extensive user data, including company and worktime regulation'
+  -
+    name: Clock
+    description: 'Control the clock'
+  -
+    name: Customer
+    description: 'Manage customers'
+  -
+    name: Entry
+    description: 'Manage time and lump sum entries'
+  -
+    name: EntryGroup
+    description: 'Query and manage groups of time entries (particularly useful for evaluation and invoicing purposes)'
+  -
+    name: EntryText
+    description: 'Query descriptions of time and lump sum entries'
+  -
+    name: Favorite
+    description: 'Manage favorites'
+  -
+    name: HolidayCarryover
+    description: 'Manage holiday carryovers'
+  -
+    name: HolidayQuota
+    description: 'Manage holiday quotas'
+  -
+    name: IndividualUserAccess
+    description: 'Manage individual user rights'
+  -
+    name: LumpSumService
+    description: 'Manage lump sum services'
+  -
+    name: NonbusinessDay
+    description: 'Query and manage nonbusiness days'
+  -
+    name: NonbusinessGroup
+    description: 'Query and manage nonbusiness groups'
+  -
+    name: OvertimeCarry
+    description: 'Manage overtime carryovers'
+  -
+    name: OvertimeReduction
+    description: 'Manage overtime reductions'
+  -
+    name: Project
+    description: 'Manage projects'
+  -
+    name: ProjectReport
+    description: 'Query projects'
+  -
+    name: Rate
+    description: 'Manage rates'
+  -
+    name: Rate
+    description: 'Manage rates'
+  -
+    name: Register
+    description: 'Create Clockodo accounts'
+  -
+    name: Service
+    description: 'Manage services'
+  -
+    name: Subproject
+    description: 'Manage subprojects'
+  -
+    name: Subscription
+    description: 'Get subscription info'
+  -
+    name: TargetHour
+    description: 'Manage target hours (planned hours)'
+  -
+    name: Team
+    description: 'Manage teams'
+  -
+    name: User
+    description: 'Manage co-workers'
+  -
+    name: UserNonbusinessDay
+    description: 'Get non-business days of user'
+  -
+    name: UserNonbusinessGroup
+    description: 'Assign non-business day groups to users and manage time periods'
+  -
+    name: UserReport
+    description: 'Query user reports (e. g. work time evaluation of each day and holiday account of each co-worker)'
+  -
+    name: WorkTime
+    description: 'Manage work times. Work times cannot be edited directly. To edit work times, edit the respective time entries or use requests for change of work time.'
+webhooks:
+  user_created:
+    path: user_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: user.created'
+      description: 'This webhook is triggered when a user created event occurs.'
+      operationId: webhook_user_created
+      requestBody:
+        description: 'The webhook payload for the user.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_user_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  user_updated:
+    path: user_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: user.updated'
+      description: 'This webhook is triggered when a user updated event occurs.'
+      operationId: webhook_user_updated
+      requestBody:
+        description: 'The webhook payload for the user.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_user_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  user_deleted:
+    path: user_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: user.deleted'
+      description: 'This webhook is triggered when a user deleted event occurs.'
+      operationId: webhook_user_deleted
+      requestBody:
+        description: 'The webhook payload for the user.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_user_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  absence_created:
+    path: absence_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: absence.created'
+      description: 'This webhook is triggered when a absence created event occurs.'
+      operationId: webhook_absence_created
+      requestBody:
+        description: 'The webhook payload for the absence.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_absence_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  absence_updated:
+    path: absence_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: absence.updated'
+      description: 'This webhook is triggered when a absence updated event occurs.'
+      operationId: webhook_absence_updated
+      requestBody:
+        description: 'The webhook payload for the absence.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_absence_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  absence_deleted:
+    path: absence_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: absence.deleted'
+      description: 'This webhook is triggered when a absence deleted event occurs.'
+      operationId: webhook_absence_deleted
+      requestBody:
+        description: 'The webhook payload for the absence.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_absence_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  absence_approved:
+    path: absence_approved
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: absence.approved'
+      description: 'This webhook is triggered when a absence approved event occurs.'
+      operationId: webhook_absence_approved
+      requestBody:
+        description: 'The webhook payload for the absence.approved event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_absence_approved'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  customer_created:
+    path: customer_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: customer.created'
+      description: 'This webhook is triggered when a customer created event occurs.'
+      operationId: webhook_customer_created
+      requestBody:
+        description: 'The webhook payload for the customer.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_customer_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  customer_updated:
+    path: customer_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: customer.updated'
+      description: 'This webhook is triggered when a customer updated event occurs.'
+      operationId: webhook_customer_updated
+      requestBody:
+        description: 'The webhook payload for the customer.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_customer_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  customer_deleted:
+    path: customer_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: customer.deleted'
+      description: 'This webhook is triggered when a customer deleted event occurs.'
+      operationId: webhook_customer_deleted
+      requestBody:
+        description: 'The webhook payload for the customer.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_customer_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  project_created:
+    path: project_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: project.created'
+      description: 'This webhook is triggered when a project created event occurs.'
+      operationId: webhook_project_created
+      requestBody:
+        description: 'The webhook payload for the project.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_project_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  project_updated:
+    path: project_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: project.updated'
+      description: 'This webhook is triggered when a project updated event occurs.'
+      operationId: webhook_project_updated
+      requestBody:
+        description: 'The webhook payload for the project.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_project_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  project_deleted:
+    path: project_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: project.deleted'
+      description: 'This webhook is triggered when a project deleted event occurs.'
+      operationId: webhook_project_deleted
+      requestBody:
+        description: 'The webhook payload for the project.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_project_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  project_completed:
+    path: project_completed
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: project.completed'
+      description: 'This webhook is triggered when a project completed event occurs.'
+      operationId: webhook_project_completed
+      requestBody:
+        description: 'The webhook payload for the project.completed event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_project_completed'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  project_budget_notification:
+    path: project_budget_notification
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: project.budget_notification'
+      description: "This webhook is triggered when a project or subproject's budget usage crosses a defined threshold.\n\n**Triggering Conditions:**\n- The project/subproject must have budget notification thresholds configured (e.g., 50%, 60%, 70%)\n- The current budget usage percentage must exceed a threshold that wasn't previously exceeded\n- The webhook only fires once per threshold level (prevents duplicate notifications)\n- The company must have a Trial or Enterprise subscription\n\n**Example Scenarios:**\n- Usage increases from 45% to 55% with a 50% threshold → webhook fires for 50%\n- Usage increases from 55% to 60% with only a 50% threshold → webhook does NOT fire (already exceeded)\n- Usage increases from 55% to 80% with thresholds at 50% and 75% → webhook fires for 75%\n\nThe `type` field in the payload indicates whether it's a `projectBudget` or `subprojectBudget` notification.\nThe `threshold` field contains the percentage value that was exceeded."
+      operationId: webhook_project_budget_notification
+      requestBody:
+        description: 'The webhook payload for the project.budget_notification event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_project_budget_notification'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  subproject_created:
+    path: subproject_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: subproject.created'
+      description: 'This webhook is triggered when a subproject created event occurs.'
+      operationId: webhook_subproject_created
+      requestBody:
+        description: 'The webhook payload for the subproject.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_subproject_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  subproject_updated:
+    path: subproject_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: subproject.updated'
+      description: 'This webhook is triggered when a subproject updated event occurs.'
+      operationId: webhook_subproject_updated
+      requestBody:
+        description: 'The webhook payload for the subproject.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_subproject_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  subproject_deleted:
+    path: subproject_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: subproject.deleted'
+      description: 'This webhook is triggered when a subproject deleted event occurs.'
+      operationId: webhook_subproject_deleted
+      requestBody:
+        description: 'The webhook payload for the subproject.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_subproject_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  service_created:
+    path: service_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: service.created'
+      description: 'This webhook is triggered when a service created event occurs.'
+      operationId: webhook_service_created
+      requestBody:
+        description: 'The webhook payload for the service.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_service_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  service_updated:
+    path: service_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: service.updated'
+      description: 'This webhook is triggered when a service updated event occurs.'
+      operationId: webhook_service_updated
+      requestBody:
+        description: 'The webhook payload for the service.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_service_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  service_deleted:
+    path: service_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: service.deleted'
+      description: 'This webhook is triggered when a service deleted event occurs.'
+      operationId: webhook_service_deleted
+      requestBody:
+        description: 'The webhook payload for the service.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_service_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  team_created:
+    path: team_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: team.created'
+      description: 'This webhook is triggered when a team created event occurs.'
+      operationId: webhook_team_created
+      requestBody:
+        description: 'The webhook payload for the team.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_team_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  team_updated:
+    path: team_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: team.updated'
+      description: 'This webhook is triggered when a team updated event occurs.'
+      operationId: webhook_team_updated
+      requestBody:
+        description: 'The webhook payload for the team.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_team_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  team_deleted:
+    path: team_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: team.deleted'
+      description: 'This webhook is triggered when a team deleted event occurs.'
+      operationId: webhook_team_deleted
+      requestBody:
+        description: 'The webhook payload for the team.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_team_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  lump_sum_service_created:
+    path: lump_sum_service_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: lump_sum_service.created'
+      description: 'This webhook is triggered when a lump_sum_service created event occurs.'
+      operationId: webhook_lump_sum_service_created
+      requestBody:
+        description: 'The webhook payload for the lump_sum_service.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_lump_sum_service_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  lump_sum_service_updated:
+    path: lump_sum_service_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: lump_sum_service.updated'
+      description: 'This webhook is triggered when a lump_sum_service updated event occurs.'
+      operationId: webhook_lump_sum_service_updated
+      requestBody:
+        description: 'The webhook payload for the lump_sum_service.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_lump_sum_service_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  lump_sum_service_deleted:
+    path: lump_sum_service_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: lump_sum_service.deleted'
+      description: 'This webhook is triggered when a lump_sum_service deleted event occurs.'
+      operationId: webhook_lump_sum_service_deleted
+      requestBody:
+        description: 'The webhook payload for the lump_sum_service.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_lump_sum_service_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  holidays_carry_created:
+    path: holidays_carry_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: holidays_carry.created'
+      description: 'This webhook is triggered when a holidays_carry created event occurs.'
+      operationId: webhook_holidays_carry_created
+      requestBody:
+        description: 'The webhook payload for the holidays_carry.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_holidays_carry_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  holidays_carry_updated:
+    path: holidays_carry_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: holidays_carry.updated'
+      description: 'This webhook is triggered when a holidays_carry updated event occurs.'
+      operationId: webhook_holidays_carry_updated
+      requestBody:
+        description: 'The webhook payload for the holidays_carry.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_holidays_carry_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  holidays_carry_deleted:
+    path: holidays_carry_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: holidays_carry.deleted'
+      description: 'This webhook is triggered when a holidays_carry deleted event occurs.'
+      operationId: webhook_holidays_carry_deleted
+      requestBody:
+        description: 'The webhook payload for the holidays_carry.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_holidays_carry_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  holidays_quota_created:
+    path: holidays_quota_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: holidays_quota.created'
+      description: 'This webhook is triggered when a holidays_quota created event occurs.'
+      operationId: webhook_holidays_quota_created
+      requestBody:
+        description: 'The webhook payload for the holidays_quota.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_holidays_quota_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  holidays_quota_updated:
+    path: holidays_quota_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: holidays_quota.updated'
+      description: 'This webhook is triggered when a holidays_quota updated event occurs.'
+      operationId: webhook_holidays_quota_updated
+      requestBody:
+        description: 'The webhook payload for the holidays_quota.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_holidays_quota_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  holidays_quota_deleted:
+    path: holidays_quota_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: holidays_quota.deleted'
+      description: 'This webhook is triggered when a holidays_quota deleted event occurs.'
+      operationId: webhook_holidays_quota_deleted
+      requestBody:
+        description: 'The webhook payload for the holidays_quota.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_holidays_quota_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  overtime_carry_created:
+    path: overtime_carry_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: overtime_carry.created'
+      description: 'This webhook is triggered when a overtime_carry created event occurs.'
+      operationId: webhook_overtime_carry_created
+      requestBody:
+        description: 'The webhook payload for the overtime_carry.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_overtime_carry_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  overtime_carry_updated:
+    path: overtime_carry_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: overtime_carry.updated'
+      description: 'This webhook is triggered when a overtime_carry updated event occurs.'
+      operationId: webhook_overtime_carry_updated
+      requestBody:
+        description: 'The webhook payload for the overtime_carry.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_overtime_carry_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  overtime_carry_deleted:
+    path: overtime_carry_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: overtime_carry.deleted'
+      description: 'This webhook is triggered when a overtime_carry deleted event occurs.'
+      operationId: webhook_overtime_carry_deleted
+      requestBody:
+        description: 'The webhook payload for the overtime_carry.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_overtime_carry_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  nonbusiness_group_created:
+    path: nonbusiness_group_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: nonbusiness_group.created'
+      description: 'This webhook is triggered when a nonbusiness_group created event occurs.'
+      operationId: webhook_nonbusiness_group_created
+      requestBody:
+        description: 'The webhook payload for the nonbusiness_group.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_nonbusiness_group_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  nonbusiness_group_updated:
+    path: nonbusiness_group_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: nonbusiness_group.updated'
+      description: 'This webhook is triggered when a nonbusiness_group updated event occurs.'
+      operationId: webhook_nonbusiness_group_updated
+      requestBody:
+        description: 'The webhook payload for the nonbusiness_group.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_nonbusiness_group_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  nonbusiness_group_deleted:
+    path: nonbusiness_group_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: nonbusiness_group.deleted'
+      description: 'This webhook is triggered when a nonbusiness_group deleted event occurs.'
+      operationId: webhook_nonbusiness_group_deleted
+      requestBody:
+        description: 'The webhook payload for the nonbusiness_group.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_nonbusiness_group_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  work_time_change_request_created:
+    path: work_time_change_request_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: work_time_change_request.created'
+      description: 'This webhook is triggered when a work_time_change_request created event occurs.'
+      operationId: webhook_work_time_change_request_created
+      requestBody:
+        description: 'The webhook payload for the work_time_change_request.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_work_time_change_request_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  work_time_change_request_updated:
+    path: work_time_change_request_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: work_time_change_request.updated'
+      description: 'This webhook is triggered when a work_time_change_request updated event occurs.'
+      operationId: webhook_work_time_change_request_updated
+      requestBody:
+        description: 'The webhook payload for the work_time_change_request.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_work_time_change_request_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  work_time_change_request_deleted:
+    path: work_time_change_request_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: work_time_change_request.deleted'
+      description: 'This webhook is triggered when a work_time_change_request deleted event occurs.'
+      operationId: webhook_work_time_change_request_deleted
+      requestBody:
+        description: 'The webhook payload for the work_time_change_request.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_work_time_change_request_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  entry_created:
+    path: entry_created
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: entry.created'
+      description: 'This webhook is triggered when a entry created event occurs.'
+      operationId: webhook_entry_created
+      requestBody:
+        description: 'The webhook payload for the entry.created event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_entry_created'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  entry_updated:
+    path: entry_updated
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: entry.updated'
+      description: 'This webhook is triggered when a entry updated event occurs.'
+      operationId: webhook_entry_updated
+      requestBody:
+        description: 'The webhook payload for the entry.updated event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_entry_updated'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  entry_deleted:
+    path: entry_deleted
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: entry.deleted'
+      description: 'This webhook is triggered when a entry deleted event occurs.'
+      operationId: webhook_entry_deleted
+      requestBody:
+        description: 'The webhook payload for the entry.deleted event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_entry_deleted'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  entry_started:
+    path: entry_started
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: entry.started'
+      description: 'This webhook is triggered when a entry started event occurs.'
+      operationId: webhook_entry_started
+      requestBody:
+        description: 'The webhook payload for the entry.started event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_entry_started'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'
+  entry_stopped:
+    path: entry_stopped
+    post:
+      tags:
+        - Webhook
+      summary: 'Webhook: entry.stopped'
+      description: 'This webhook is triggered when a entry stopped event occurs.'
+      operationId: webhook_entry_stopped
+      requestBody:
+        description: 'The webhook payload for the entry.stopped event'
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookEvent_entry_stopped'
+      responses:
+        '200':
+          description: 'Return a 200 status to indicate that the data was received successfully'


### PR DESCRIPTION
## Summary
- Add `specification/openapi.yaml` pinned at info.version `2026-05-06` (fresh download from https://docs.clockodo.com/openapi.yaml). Replaces the untracked Jan-13 snapshot.
- Drop `/v2/` suffix from `CLOCKODO_BASE_URL` defaults in `Dockerfile`, `docker-compose.yml`, and `README.md`. Cosmetic — `client.py:51` strips version suffixes at runtime — but the default should reflect that most resources live at `/v3/` or `/v4/`.

## Migration scope check (re: 2026-05-18 deprecation)
Verified every call in `src/clockodo_mcp/client.py` against the live blog deprecation table and the fresh spec:

| Call | Status |
|---|---|
| `v3/users`, `v3/customers` | listed as successors ✅ |
| `v4/services`, `v4/projects`, `v4/absences` | listed as successors ✅ |
| `v2/clock`, `v2/entries` | not in deprecation table; still current in 2026-05-06 spec ✅ |

No client code change required. Tracking issue #20 stays open until we confirm with Clockodo support what flagged the account.

## Test plan
- [x] `make test` — 186 passed, 89.92% coverage
- [ ] CI green