### PR TITLE
fix: stop double-counting overtime carryover in HR summary (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **HR Overtime Double-Count** (#24): `get_hr_summary` / `check_overtime_compliance` no longer add the prior-year overtime carryover on top of `diff`. Clockodo's `diff` already includes the carryover, so the previous behaviour inflated balances and produced false-positive `excessive_overtime` violations. `overtime_hours` now equals `diff / 3600`.
+
 ## [0.3.1] - 2026-01-14
 
 ### Added

--- a/src/clockodo_mcp/hr_analyzer.py
+++ b/src/clockodo_mcp/hr_analyzer.py
@@ -12,13 +12,12 @@ def analyze_overtime(report: dict, max_hours_threshold: float) -> dict:
     Returns:
         Dictionary with overtime analysis results
     """
-    # Convert seconds to hours
+    # Convert seconds to hours. Clockodo's `diff` is already the current
+    # overtime balance with the prior-year carryover folded in
+    # (sum_hours + overtime_carryover - sum_target). Adding the carryover
+    # again would double-count it and inflate the balance (see issue #24).
     diff_seconds = report.get("diff") or 0
-    carryover_seconds = report.get("overtime_carryover") or 0
-
-    diff_hours = float(diff_seconds) / 3600
-    carryover_hours = float(carryover_seconds) / 3600
-    total_overtime = diff_hours + carryover_hours
+    total_overtime = float(diff_seconds) / 3600
 
     has_violation = total_overtime > max_hours_threshold
 

--- a/tests/test_hr_analyzer.py
+++ b/tests/test_hr_analyzer.py
@@ -10,8 +10,10 @@ def test_analyze_overtime_no_violation_when_under_threshold():
         "users_id": 1,
         "users_name": "Alice",
         "year": 2024,
+        # diff already includes the carryover; the carryover here must be
+        # ignored so the balance is not double-counted (see issue #24).
         "diff": 72000,  # 20 hours in seconds
-        "overtime_carryover": 0,
+        "overtime_carryover": 282060,  # 78.35 hours, already folded into diff
     }
 
     result = analyze_overtime(report, max_hours_threshold=80)
@@ -26,15 +28,34 @@ def test_analyze_overtime_violation_when_exceeds_threshold():
         "users_id": 2,
         "users_name": "Bob",
         "year": 2024,
-        "diff": 288000,  # 80 hours in seconds
-        "overtime_carryover": 18000,  # 5 hours in seconds
+        # diff is the current overtime balance, carryover already folded in.
+        "diff": 360000,  # 100 hours in seconds
+        "overtime_carryover": 18000,  # 5 hours, must NOT be added on top
     }
 
     result = analyze_overtime(report, max_hours_threshold=80)
 
     assert result["has_violation"] is True
-    assert result["overtime_hours"] == 85.0
-    assert result["excess_hours"] == 5.0
+    assert result["overtime_hours"] == 100.0
+    assert result["excess_hours"] == 20.0
+
+
+def test_analyze_overtime_does_not_double_count_carryover():
+    """Regression for issue #24: carryover is already part of diff."""
+    # Stefan Huwiler production case: actual balance 61.43 h (under 80 h),
+    # was falsely flagged because carryover (78.35 h) was added on top.
+    report = {
+        "users_id": 424877,
+        "users_name": "Stefan Huwiler",
+        "year": 2026,
+        "diff": 221150,  # 61.43 hours — the real balance
+        "overtime_carryover": 282060,  # 78.35 hours, already in diff
+    }
+
+    result = analyze_overtime(report, max_hours_threshold=80)
+
+    assert abs(result["overtime_hours"] - 61.4306) < 0.01
+    assert result["has_violation"] is False
 
 
 def test_analyze_overtime_with_negative_diff():


### PR DESCRIPTION
## Summary
Fixes #24. `analyze_overtime` added the prior-year `overtime_carryover` on top of `diff`, but Clockodo's `diff` already includes the carryover (`sum_hours + overtime_carryover - sum_target`). This double-counted the carryover, inflating overtime balances and producing false-positive `excessive_overtime` violations for users actually under the threshold.

## Change
- `overtime_hours` now equals `diff / 3600` directly; `overtime_carryover` is no longer added.

## Tests
- Updated `analyze_overtime` tests to assert carryover is ignored.
- Added regression test using the production Stefan Huwiler case (61.43 h balance, 78.35 h carryover) — previously flagged as excessive, now correctly under threshold.
- Full suite: 187 passed. Lint 10/10, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)