### PR TITLE
feat: add get_my_absences tool (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Self-Service Absence Listing** (#25): New `get_my_absences(year, absence_type=None)` tool lists the authenticated user's absences for a year across all statuses (enquired, approved, declined). Each entry includes the `id` required by `delete_my_vacation` / `adjust_vacation_dates`, plus `date_since`, `date_until`, `type`, `status` and `count_days`.
+
 ## [0.3.1] - 2026-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ The following are still supported but deprecated. Use `CLOCKODO_MCP_ROLE` instea
 ### User Tools (when `USER_READ` or `USER_EDIT` enabled)
 - `get_my_clock()` - Get currently running clock
 - `get_my_time_entries(time_since, time_until)` - Get your time entries
+- `get_my_absences(year, absence_type=None)` - List your absences for a year (all statuses), including the `absence_id` needed to delete or adjust them
 - `start_my_clock(...)` - Start tracking time
 - `stop_my_clock()` - Stop tracking time
 - `add_my_time_entry(...)` - Add a manual time entry

--- a/src/clockodo_mcp/server.py
+++ b/src/clockodo_mcp/server.py
@@ -248,6 +248,21 @@ def _register_user_read_tools():
         """
         return user_tools.get_my_entries(time_since, time_until)
 
+    @mcp.tool()
+    def get_my_absences(year: int, absence_type: int | None = None) -> dict:
+        """
+        List the authenticated user's absences for a year (all statuses).
+
+        Returns each absence with its id, date_since, date_until, type, status
+        and count_days. The id is required to delete or adjust an absence.
+
+        Args:
+            year: Calendar year to list absences for
+            absence_type: Optional absence type to filter by (e.g. 1 = vacation,
+                2 = illness). When omitted, all types are returned.
+        """
+        return user_tools.get_my_absences(year, absence_type)
+
 
 def _register_user_edit_tools():
     """Register user edit tools."""
@@ -435,7 +450,7 @@ def create_server(client=None, test_config: ServerConfig | None = None):
                     ]
                 )
             if test_conf.user_read:
-                self.tool_names.append("get_my_time_entries")
+                self.tool_names.extend(["get_my_time_entries", "get_my_absences"])
             if test_conf.user_edit:
                 self.tool_names.extend(["add_my_time_entry", "delete_my_vacation"])
             if test_conf.team_leader:

--- a/src/clockodo_mcp/services/user_service.py
+++ b/src/clockodo_mcp/services/user_service.py
@@ -93,6 +93,32 @@ class UserService:
             user_id=user_id,
         )
 
+    def get_my_absences(self, year: int, absence_type: int | None = None) -> dict:
+        """
+        List the authenticated user's absences for a given year.
+
+        Returns absences of all statuses (enquired, approved, declined, ...),
+        each carrying the ``id`` needed by ``delete_my_vacation`` and
+        ``adjust_vacation_dates``, along with the date range, type, status and
+        day count.
+
+        Args:
+            year: Calendar year to list absences for.
+            absence_type: Optional Clockodo absence type to filter by
+                (e.g. 1 = vacation, 2 = illness). When ``None`` all types are
+                returned.
+        """
+        user_id = self.get_current_user_id()
+        raw = self.client.list_absences(year)
+
+        absences = [
+            absence
+            for absence in raw.get("absences") or []
+            if absence.get("users_id") == user_id
+            and (absence_type is None or absence.get("type") == absence_type)
+        ]
+        return {"absences": absences}
+
     def get_my_entries(self, time_since: str, time_until: str) -> dict:
         """Get time entries for the current user."""
         user_id = self.get_current_user_id()

--- a/src/clockodo_mcp/tools/user_tools.py
+++ b/src/clockodo_mcp/tools/user_tools.py
@@ -74,6 +74,20 @@ def get_my_entries(time_since: str, time_until: str) -> dict:
     return service.get_my_entries(time_since, time_until)
 
 
+def get_my_absences(year: int, absence_type: int | None = None) -> dict:
+    """
+    List the authenticated user's absences for a given year.
+
+    Args:
+        year: Calendar year to list absences for
+        absence_type: Optional absence type to filter by (e.g. 1 = vacation,
+            2 = illness). When omitted, absences of all types are returned.
+    """
+    client = ClockodoClient.from_env()
+    service = UserService(client)
+    return service.get_my_absences(year, absence_type)
+
+
 def add_my_entry(
     customers_id: int,
     services_id: int,

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -326,3 +326,87 @@ def test_delete_my_entry():
 
     client.delete_entry.assert_called_once_with(3001)
     assert result["success"] is True
+
+
+def _absence(absence_id, users_id, abs_type=1, status=1):
+    return {
+        "id": absence_id,
+        "users_id": users_id,
+        "date_since": "2025-07-01",
+        "date_until": "2025-07-05",
+        "type": abs_type,
+        "status": status,
+        "count_days": 5,
+        "note": "Summer holiday",
+    }
+
+
+def _absence_client():
+    client = MagicMock()
+    client.api_user = "alice@example.com"
+    client.list_users.return_value = {
+        "users": [{"id": 42, "email": "alice@example.com"}]
+    }
+    return client
+
+
+def test_get_my_absences_filters_to_current_user():
+    """Only the authenticated user's absences should be returned."""
+    client = _absence_client()
+    client.list_absences.return_value = {
+        "absences": [
+            _absence(2001, 42),
+            _absence(2002, 99),  # another user, must be filtered out
+        ]
+    }
+
+    service = UserService(client)
+    result = service.get_my_absences(year=2025)
+
+    client.list_absences.assert_called_once_with(2025)
+    ids = [a["id"] for a in result["absences"]]
+    assert ids == [2001]
+
+
+def test_get_my_absences_includes_all_statuses():
+    """Approved and enquired absences alike are returned (all statuses)."""
+    client = _absence_client()
+    client.list_absences.return_value = {
+        "absences": [
+            _absence(2001, 42, status=0),  # enquired
+            _absence(2002, 42, status=1),  # approved
+            _absence(2003, 42, status=2),  # declined
+        ]
+    }
+
+    service = UserService(client)
+    result = service.get_my_absences(year=2025)
+
+    assert {a["id"] for a in result["absences"]} == {2001, 2002, 2003}
+
+
+def test_get_my_absences_filters_by_type():
+    """Optional absence_type narrows results to a single type."""
+    client = _absence_client()
+    client.list_absences.return_value = {
+        "absences": [
+            _absence(2001, 42, abs_type=1),  # vacation
+            _absence(2002, 42, abs_type=2),  # illness
+        ]
+    }
+
+    service = UserService(client)
+    result = service.get_my_absences(year=2025, absence_type=2)
+
+    assert [a["id"] for a in result["absences"]] == [2002]
+
+
+def test_get_my_absences_handles_missing_absences_key():
+    """A response without absences yields an empty list, not an error."""
+    client = _absence_client()
+    client.list_absences.return_value = {}
+
+    service = UserService(client)
+    result = service.get_my_absences(year=2025)
+
+    assert result["absences"] == []


### PR DESCRIPTION
## Summary
Closes #25. Adds a self-service tool to list the authenticated user's absences, filling the gap where the server could create/delete absences but offered no way to discover existing ones or their `absence_id`.

## Change
- `UserService.get_my_absences(year, absence_type=None)` — calls `list_absences`, filters to the current user, optionally by type. Returns all statuses (enquired, approved, declined).
- `user_tools.get_my_absences` wrapper + registration under `USER_READ`.
- README tool list + CHANGELOG updated.

## Acceptance criteria (from #25)
- [x] Returns all of the current user's absences for a year, including approved ones (all statuses).
- [x] Each entry includes `id`, `date_since`, `date_until`, `type`, `status`, `count_days` (returned verbatim from Clockodo).
- [x] Optional filtering by `absence_type`.
- [x] Documented in the README tool list.

## Tests
- 4 new service tests (user filtering, all-statuses, type filter, missing-key). Full suite: 190 passed. Lint 10/10, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)