### PR TITLE
chore: cover unfixable base-image CVEs in .trivyignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ sbom.spdx.json
 # IDEs
 .idea/
 src/clockodo_mcp/_version.py
+
+# Local tool logs
+firebase-debug.log
+firebase-debug.*.log
+
+# Local agent instructions (contains personal preferences — do not publish)
+/CLAUDE.md

--- a/.trivyignore
+++ b/.trivyignore
@@ -32,10 +32,11 @@ CVE-2024-0232   # FTS5 integer overflow - we don't use FTS5 features
 CVE-2026-0861   # Integer overflow in memalign leads to heap corruption
 
 # ncurses buffer overflow — affects libncursesw6, libtinfo6, ncurses-base.
-# No fix in Debian trixie as of 2026-05. Trivy reports HIGH but the buffer
-# overflow is in tic/infocmp local utilities not invoked by this server.
-# Re-evaluate by 2026-08-10.
-CVE-2025-69720 exp:2026-08-10
+# Still no fix in Debian trixie as of 2026-07 (status: affected). Trivy
+# reports HIGH but the buffer overflow is in tic/infocmp local utilities
+# not invoked by this server.
+# Re-evaluate by 2026-09-15.
+CVE-2025-69720 exp:2026-09-15
 
 # systemd arbitrary code execution / DoS — affects libsystemd0, libudev1.
 # No fix in Debian trixie as of 2026-05. We don't run systemd inside the
@@ -51,3 +52,44 @@ CVE-2026-29111 exp:2026-08-10
 # making the attack vector unreachable.
 # Re-evaluate by 2026-08-10.
 CVE-2026-4878 exp:2026-08-10
+
+# perl-base — Archive::Tar / IO-Compress / Storable / perl interpreter issues.
+# No fix in Debian trixie as of 2026-07 (statuses: fix_deferred / affected;
+# verified against a freshly pulled python:3.13-slim, Debian 13.6,
+# perl-base 5.40.1-6). perl is a base-image essential package (dpkg depends
+# on perl-base) and is never invoked by this server, which runs
+# `python -m clockodo_mcp` with no perl, tar or archive processing in the
+# runtime path.
+# Re-evaluate by 2026-09-15.
+CVE-2026-42496 exp:2026-09-15   # perl-Archive-Tar path traversal (CRITICAL)
+CVE-2026-8376 exp:2026-09-15    # perl heap buffer overflow (CRITICAL)
+CVE-2026-42497 exp:2026-09-15   # perl-Archive-Tar arbitrary file write
+CVE-2026-48962 exp:2026-09-15   # perl-IO-Compress arbitrary code execution
+CVE-2026-9538 exp:2026-09-15    # Archive::Tar < 3.10 memory handling
+CVE-2026-13221 exp:2026-09-15   # perl regex silently incorrect results (CRITICAL)
+CVE-2026-57433 exp:2026-09-15   # perl Storable signed integer overflow (CRITICAL)
+CVE-2026-57432 exp:2026-09-15   # perl S_measure_struct integer overflow (HIGH)
+
+# acl / attr symlink-traversal privilege escalation — affects libacl1 and
+# libattr1. No fix in Debian trixie as of 2026-07. The escalation requires a
+# privileged process walking attacker-controlled symlinks; this image runs as
+# the non-root `appuser` (Dockerfile:42) and performs no acl/xattr operations.
+# Re-evaluate by 2026-09-15.
+CVE-2026-54369 exp:2026-09-15   # libacl1 symlink traversal
+CVE-2026-54371 exp:2026-09-15   # libattr1 symlink traversal
+
+# gzip global buffer overflow in the LZH decoder — affects gzip. No fix in
+# Debian trixie as of 2026-07 (status: affected). gzip is a base-image
+# package; this server never decompresses untrusted .lzh/.gz input, so the
+# vulnerable decoder path is unreachable.
+# Re-evaluate by 2026-09-15.
+CVE-2026-41992 exp:2026-09-15   # gzip LZH decoder buffer overflow
+
+# util-linux integer overflow in libblkid DOS-partition parser — affects
+# util-linux, mount, login, libblkid1, libmount1, libuuid1, libsmartcols1,
+# liblastlog2-2, bsdutils (HIGH). No fix in Debian trixie as of 2026-07
+# (status: affected). The overflow is triggered by probing a crafted
+# partition table; this container never probes block devices — no volumes
+# are mounted at runtime and the server runs as non-root `appuser`.
+# Re-evaluate by 2026-09-15.
+CVE-2026-53615 exp:2026-09-15   # libblkid dos.c integer overflow


### PR DESCRIPTION
## Summary

Completes the base-image CVE remediation started on this branch. The CRITICAL/HIGH Trivy gate (`docker-publish.yml`, `security-scan-scheduled.yml`) now passes with **0 findings**.

### Why ignore instead of bumping the base image

The image was rebuilt with `docker build --pull` against the freshest `python:3.13-slim` (Debian 13.6) and re-scanned with the latest Trivy: **every reported CVE has no fixed package version in trixie** (status `affected` / `fix_deferred`). A base-image bump therefore cannot remediate any of them today — the ignore list is the only option, and every entry carries an `exp:2026-09-15` expiry to force re-evaluation.

### Newly ignored (all NO-FIX in trixie, each with a reachability justification)

| Package | CVEs | Severity | Why acceptable |
|---|---|---|---|
| perl-base | CVE-2026-42496, CVE-2026-8376, CVE-2026-13221, CVE-2026-57433, CVE-2026-42497, CVE-2026-48962, CVE-2026-9538, CVE-2026-57432 | 4x CRITICAL, 4x HIGH | perl is a dpkg-essential package, never invoked by the Python server |
| libacl1 / libattr1 | CVE-2026-54369, CVE-2026-54371 | HIGH / MEDIUM | requires a privileged process; container runs as non-root `appuser` |
| gzip | CVE-2026-41992 | HIGH | LZH decoder path unreachable, no untrusted archive processing |
| util-linux family | CVE-2026-53615 | HIGH | libblkid partition probing never happens in this container |

### Also

- Extended `CVE-2025-69720` (ncurses, still unfixed) from `exp:2026-08-10` to `exp:2026-09-15` so the scheduled scan does not start failing in two weeks.
- Gitignored the stray local `firebase-debug.log` and the personal `CLAUDE.md` (contains personal preferences/IDs — must not land in this public repo).

### Not ignored

MEDIUM base-image findings (glibc, sqlite3, zlib, bz2, pam, tar, further perl/util-linux issues) remain visible: CI reports MEDIUM informationally with `exit-code: 0`, so they don't gate and staying visible is preferable to widening the ignore list.

### Verification

- `docker build --pull` + Trivy `--severity CRITICAL,HIGH --exit-code 1` with this `.trivyignore`: exit 0, 0 findings.
- `make test` (Docker): 186 passed, coverage 89.92%.